### PR TITLE
docs: live CLAUDE.md spine (replace grok-era tombstone)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,28 @@
-# Historical CLAUDE.md (Claude-era VCEO loader)
+# @devify/ui — Tool Operating Context
 
-This file is retained for git history only. It contained the old dual-VCEO (Grob/Claude + Xavior/Grok) project-specific instructions and context at the time of the 2026-05 transition.
+A Claude session with `cwd` here is **working on `@devify/ui`**, the Devify design system: a zero-build HTML Web Component library (~54 components + HTMX patterns) and the three-tier design-token system that every Devify project themes against. No framework, no bundler — just HTML, CSS, and ES modules. This file is the always-loaded spine; load the docs below on demand (Precision Context).
 
-**Relevant knowledge has been reviewed** as part of the 2026-06 big-bang archival + cutover to the Grok-Build native + studio OS model (to avoid losing any value from the "messy as it was, but working" system).
+## Status
 
-- Project-specific guardrails, architecture, milestones, data models, commands, and workflows: Now live in this project's `docs/` (specs, business/, architecture/), `tasks/todo.md`, and code.
-- Old VCEO/dual loader content and the broader methodology at the cutover point: Preserved exactly in the dedicated archival snapshot:
-  https://github.com/devify-me/devify-vceo-claude (main branch = pre-Xavior backup state from 2026-05-27).
-- Current model (Grok Build VEmployees/personas, Precision Context, devify-hr gate, standardized structures, upward synthesis via learn, G&P in department templates): See `~/devify/studio/` (https://github.com/devify-me/studio) and the active `.grok/` configuration + hooks at the devify root.
+Active and maintained (v0.2.0, recent component work through 2026-06). This is `tools/` (shared platform tooling), not `studio/` — standards are governed by `studio/`; this repo builds the components everything else consumes.
 
-The valuable patterns from the old system (explicit planning/todo discipline, durable FS memory via Business Topics, clear guardrails, milestone verification, etc.) directly informed the v0.2 operating model and studio layer. No information was lost.
+## Where knowledge lives (load on need)
+
+- `README.md` — what it is, install/usage, full component list, theming, file structure. Start here.
+- **Live catalog** — `npm run serve` → `http://localhost:8090/catalog/` for interactive examples + the API viewer (driven by `custom-elements.json`).
+- `docs/` — durable knowledge: `taxonomy.md` (component categories), `conventions.md` (cross-component design decisions + static-check allowlisting), `new-component-checklist.md`, `component-review-checklist.md`, `consuming-projects.md`, `a11y-testing-guide.md` / `wcag-compliance.md` / `wcag-contrast-audit.md`, `pwa.md`, `releasing.md`, `migration.md`, `specs/`.
+- `CONTRIBUTING.md`, `FORM_VALIDATION_PATTERN.md` — contribution + form patterns.
+- `.claude/skills/` — project skills: `new-component`, `catalog-review`.
+- `tasks/todo.md` — current work item / scope.
+
+## Architecture & gotchas (know before you change things)
+
+- **Three-tier tokens:** primitives (`tokens/*.css`) → semantics (`tokens/themes/*.css`: light, dark, devify-cyan, devify-pink) → component-scoped overrides. **All color must flow through `--dvfy-*` semantic tokens** — no hardcoded literals. This is the contract that makes theming work, and it is the same token system the studio `design-thinking` skill requires *consuming* projects (rueda etc.) to design against.
+- **Light DOM only** (no Shadow DOM) — required for HTMX compatibility. Attributes are the component API.
+- **Zero build step** — ES modules served directly; `devify.css` + `devify.js` are the bundles consumers import.
+- **`dvfy-` prefix** on all element + class names. Container queries (parent width), not viewport, on responsive components.
+- **Static gates enforce the above:** `npm run lint` runs eslint + stylelint + `check:tokens` (no hardcoded colors) + `check:dvfy-pref` (prefer `<dvfy-*>` over native). Tests: `npm run test` (web-test-runner + Playwright). Regenerate the manifest after API changes: `npm run analyze` → `custom-elements.json`. See `docs/conventions.md` for the allowlisting mechanisms.
+
+## Conventions
+
+Devify standards apply — see root `~/devify/CLAUDE.md` + `studio/`: G&P before building, Verification-Before-Completion, branch+PR (never push to main), commit author = Jorge, no AI attribution in git, never read secret files. Repo-specific component/contribution rules live in `docs/` (above), not here.


### PR DESCRIPTION
Replaces the grok-era tombstone `CLAUDE.md` ("retained for git history only", still pointing at the retired `.grok/` harness) with a live, right-sized project spine: what this repo is, current status, lazy references to its docs, key gotchas, and a conventions line that defers to root `~/devify/CLAUDE.md` + `studio/`.

Completes a piece of the Grok→Claude migration that was left behind: every component repo kept a tombstone that auto-loads misleading/stale context into any session working there. Doc-only — no code touched.