### PR TITLE
feat(themes): Renting Ideal theme + root-cause AA fix in theme-generator (G1, #366, closes #369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Three-tier token system following [UI Collective](https://uicollective.co/) meth
 | Default | `light` / `dark` | Neutral gray | Dark slate |
 | Devify Cyan | `devify-cyan` | `devify-cyan-dark` | Cyan primary |
 | Devify Pink | `devify-pink` | `devify-pink-dark` | Pink primary |
+| Renting Ideal | `renting-ideal` | `renting-ideal-dark` | Sage-green primary (named brand artifact) |
 
 ### Theme Switcher
 
@@ -248,7 +249,9 @@ devify-ui/
 │       ├── light.css       # Default light theme
 │       ├── dark.css        # Default dark theme
 │       ├── devify-cyan.css # Cyan brand (light + dark)
-│       └── devify-pink.css # Pink brand (light + dark)
+│       ├── devify-pink.css # Pink brand (light + dark)
+│       ├── renting-ideal.css        # Renting Ideal brand — generated, read-only
+│       └── renting-ideal.brand.json # ↑ its seed/brief (regenerate, never hand-edit)
 ├── components/             # 48 Web Components
 │   ├── dvfy-button.js
 │   ├── dvfy-input.js

--- a/catalog/catalog.js
+++ b/catalog/catalog.js
@@ -35,6 +35,10 @@ if (savedFonts) {
 const DEFAULT_THEMES = [
   { name: 'devify-blue', label: 'Devify Blue', brandColors: ['#00E5E5', '#FF3CAC'], brandIndex: 0 },
   { name: 'devify-pink', label: 'Devify Pink', brandColors: ['#FF3CAC', '#00E5E5'], brandIndex: 0 },
+  // Named brand artifact (devify-ui#366) — also shipped as a static read-only
+  // file (tokens/themes/renting-ideal.css) for by-name consumption. Listed here
+  // so it is selectable in the catalog theme-switcher.
+  { name: 'renting-ideal', label: 'Renting Ideal', brandColors: ['#5A7E65'], brandIndex: 0 },
 ];
 
 // Ensure default themes exist and are up-to-date.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "serve": "python3 -m http.server 8090",
     "contrast": "node scripts/check-contrast.js",
     "contrast:ci": "node scripts/check-contrast.js --ci",
+    "themes:gen": "node scripts/generate-named-theme.mjs",
+    "themes:check": "node scripts/generate-named-theme.mjs --check",
     "check:tokens": "node scripts/check-no-hardcoded.mjs --ci",
     "check:dvfy-pref": "node scripts/check-dvfy-preference.mjs --ci",
     "lint": "npm run lint:js && npm run lint:css && npm run check:tokens && npm run check:dvfy-pref",

--- a/scripts/check-contrast.js
+++ b/scripts/check-contrast.js
@@ -158,6 +158,7 @@ function loadThemes() {
   const darkCss       = readFileSync(join(ROOT, 'tokens/themes/dark.css'), 'utf8');
   const cyanCss       = readFileSync(join(ROOT, 'tokens/themes/devify-cyan.css'), 'utf8');
   const pinkCss       = readFileSync(join(ROOT, 'tokens/themes/devify-pink.css'), 'utf8');
+  const rentingCss    = readFileSync(join(ROOT, 'tokens/themes/renting-ideal.css'), 'utf8');
 
   const primitives    = parseCssVars(primitivesCss);
   const lightVars     = extractSelectorVars(lightCss, ':root');
@@ -166,16 +167,15 @@ function loadThemes() {
   const cyanDarkVars  = extractSelectorVars(cyanCss, '[data-theme="devify-cyan-dark"]');
   const pinkVars      = extractSelectorVars(pinkCss, '[data-theme="devify-pink"]');
   const pinkDarkVars  = extractSelectorVars(pinkCss, '[data-theme="devify-pink-dark"]');
-  // NOTE: renting-ideal is intentionally NOT registered in this gating check yet.
-  // The faithful port of the #5A7E65 sage brand inherits WCAG AA failures from the
-  // shared theme-generator's status-on rules (--dvfy-on-success/warning/info and the
-  // dark primary-text pair) — the same failures the original rueda fork carried.
-  // Fixing them is a brand/generator decision surfaced in devify-ui#366, not a port
-  // task. Register here once that remediation lands (Session 3 / Engineering).
+  const rentingVars     = extractSelectorVars(rentingCss, '[data-theme="renting-ideal"]');
+  const rentingDarkVars = extractSelectorVars(rentingCss, '[data-theme="renting-ideal-dark"]');
 
   // Merge strategy: primitives (:root) → light semantic base → theme overrides.
   // Partial brand themes (cyan/pink) only override their accent colours;
-  // all other tokens cascade from the light base.
+  // all other tokens cascade from the light base. renting-ideal is a FULL
+  // semantic theme (self-contained concrete values), so it stands on its own
+  // over the primitive base — its on-status + primary-text tokens are now
+  // AA-correct by construction (theme-generator.js / devify-ui#369).
   return {
     'light':            { ...primitives, ...lightVars },
     'dark':             { ...primitives, ...lightVars, ...darkVars },
@@ -183,6 +183,8 @@ function loadThemes() {
     'devify-cyan-dark': { ...primitives, ...lightVars, ...cyanDarkVars },
     'devify-pink':      { ...primitives, ...lightVars, ...pinkVars },
     'devify-pink-dark': { ...primitives, ...lightVars, ...pinkDarkVars },
+    'renting-ideal':      { ...primitives, ...rentingVars },
+    'renting-ideal-dark': { ...primitives, ...rentingDarkVars },
   };
 }
 

--- a/scripts/check-contrast.js
+++ b/scripts/check-contrast.js
@@ -166,6 +166,12 @@ function loadThemes() {
   const cyanDarkVars  = extractSelectorVars(cyanCss, '[data-theme="devify-cyan-dark"]');
   const pinkVars      = extractSelectorVars(pinkCss, '[data-theme="devify-pink"]');
   const pinkDarkVars  = extractSelectorVars(pinkCss, '[data-theme="devify-pink-dark"]');
+  // NOTE: renting-ideal is intentionally NOT registered in this gating check yet.
+  // The faithful port of the #5A7E65 sage brand inherits WCAG AA failures from the
+  // shared theme-generator's status-on rules (--dvfy-on-success/warning/info and the
+  // dark primary-text pair) — the same failures the original rueda fork carried.
+  // Fixing them is a brand/generator decision surfaced in devify-ui#366, not a port
+  // task. Register here once that remediation lands (Session 3 / Engineering).
 
   // Merge strategy: primitives (:root) → light semantic base → theme overrides.
   // Partial brand themes (cyan/pink) only override their accent colours;

--- a/scripts/generate-named-theme.mjs
+++ b/scripts/generate-named-theme.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * generate-named-theme.mjs — Regenerate a named brand theme CSS file.
+ *
+ * Named brand themes (e.g. renting-ideal) are author-time artifacts:
+ * regenerable from a committed brand brief (`tokens/themes/<name>.brand.json`),
+ * NEVER hand-edited. This is the same catalog/palette mechanism that produces
+ * devify-cyan / devify-pink — generatePalette() -> generateTheme() — just run
+ * at author time so the semantic token set ships as a static, read-only file.
+ *
+ * The emitted CSS carries the FULL semantic layer (concrete hex values, so the
+ * theme is self-contained for brand hues that are not in tokens/colors.css),
+ * with a distinct `<name>` (light) and `<name>-dark` (dark) selector — never
+ * palette-only (integration KB §3: palette-only means light == dark and
+ * components fall back to the default brand).
+ *
+ * Usage:
+ *   node scripts/generate-named-theme.mjs renting-ideal
+ *   node scripts/generate-named-theme.mjs            # regenerates all *.brand.json
+ *
+ * Pass --check to verify the committed CSS matches the brief (no write); exits 1
+ * on drift. This is the guard that keeps the output regenerable and un-hand-edited.
+ */
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generatePalette } from '../tokens/palette-generator.js';
+import { generateTheme } from '../tokens/theme-generator.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const THEMES_DIR = join(__dirname, '..', 'tokens', 'themes');
+
+const CHECK = process.argv.includes('--check');
+const names = process.argv.slice(2).filter(a => !a.startsWith('--'));
+
+function briefsToBuild() {
+  if (names.length) return names.map(n => `${n}.brand.json`);
+  return readdirSync(THEMES_DIR).filter(f => f.endsWith('.brand.json'));
+}
+
+function emitBlock(selector, map) {
+  let out = `[data-theme="${selector}"] {\n`;
+  for (const [prop, val] of Object.entries(map)) out += `  ${prop}: ${val};\n`;
+  out += '}\n';
+  return out;
+}
+
+function renderCss(brief) {
+  const { name, label, tagline, seed, provenance } = brief;
+  const palette = generatePalette(seed);
+  const { light, dark } = generateTheme(palette, seed.brandIndex ?? 0);
+
+  const header =
+    `/*\n` +
+    ` * @devify/ui — ${label} Theme (${name})\n` +
+    ` *\n` +
+    ` * ${tagline ? `"${label} — ${tagline}".\n * ` : ''}` +
+    `Generated, read-only. DO NOT hand-edit.\n` +
+    ` * Regenerate: node scripts/generate-named-theme.mjs ${name}\n` +
+    ` * Source of truth: tokens/themes/${name}.brand.json (seed ${seed.brandColors.join(', ')}).\n` +
+    ` *\n` +
+    ` * ${provenance}\n` +
+    ` *\n` +
+    ` * Activate with data-theme="${name}" (light) or data-theme="${name}-dark" (dark).\n` +
+    ` * Full semantic layer (light != dark), self-contained concrete values.\n` +
+    ` */\n\n`;
+
+  return `${header}${emitBlock(name, light)}\n${emitBlock(`${name}-dark`, dark)}`;
+}
+
+let drift = 0;
+for (const briefFile of briefsToBuild()) {
+  const briefPath = join(THEMES_DIR, briefFile);
+  const brief = JSON.parse(readFileSync(briefPath, 'utf8'));
+  const css = renderCss(brief);
+  const outPath = join(THEMES_DIR, `${brief.name}.css`);
+
+  if (CHECK) {
+    let current = '';
+    try { current = readFileSync(outPath, 'utf8'); } catch { /* missing */ }
+    if (current !== css) {
+      console.error(`DRIFT: ${brief.name}.css is out of date — run: node scripts/generate-named-theme.mjs ${brief.name}`);
+      drift += 1;
+    } else {
+      console.log(`OK: ${brief.name}.css matches brief`);
+    }
+  } else {
+    writeFileSync(outPath, css);
+    console.log(`wrote ${brief.name}.css (seed ${brief.seed.brandColors.join(', ')})`);
+  }
+}
+
+if (CHECK && drift > 0) process.exit(1);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,9 +6,22 @@ Follow studio/ standards: G&P, Verification Before Completion, citations to `stu
 
 **Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
 
-## Current Focus
+## Current Focus — devify-ui#369: AA-correct theme-generator (PR #368)
 
-- [ ] ...
+G&P: Make `tokens/theme-generator.js` derive on-status + dark primary text by
+measured WCAG-AA contrast (not a fixed near-black/near-white assumption), so every
+seed produces an AA-passing theme. Preserve brand hues — only adjust the on-color/text.
+
+- [ ] Add a contrast-aware on-color selector helper to theme-generator.js (pick black/white/nearest passing tier by measured ratio vs the actual bg)
+- [ ] Apply to --dvfy-on-success / -warning / -info / -danger (light + dark)
+- [ ] Apply to --dvfy-primary-text vs --dvfy-primary-bg (light + dark — dark CTA is highest-stakes)
+- [ ] Regenerate renting-ideal.css via npm run themes:gen
+- [ ] Regenerate cyan/pink/light/dark via their generators (drift-check green)
+- [ ] Register renting-ideal in check-contrast.js + remove the temporary exclusion NOTE
+- [ ] contrast:ci green for ALL themes (incl renting-ideal + -dark)
+- [ ] lint + themes:check green
+- [ ] Real-browser Playwright: status badges + dark CTA legible; brand hues unchanged before/after
+- [ ] Commit (author Jorge, no AI attribution), push, update PR #368 (+Closes #369)
 
 ## Backlog
 

--- a/tokens/theme-generator.js
+++ b/tokens/theme-generator.js
@@ -9,6 +9,82 @@
  */
 import { hexToOklch, oklchToHex, generateScale } from './palette-generator.js';
 
+// ── WCAG contrast helpers (mirrors scripts/check-contrast.js) ─────────
+// On-color / text selection is AA-correct BY CONSTRUCTION: the foreground is
+// chosen by measured contrast ratio against the *actual* background, never a
+// fixed near-black/near-white assumption. This only ever changes the
+// foreground (text/on-color) — the brand background hue is never touched.
+
+const AA_NORMAL = 4.5;
+
+function _hexToRgb(hex) {
+  hex = hex.trim().replace(/^#/, '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  const n = parseInt(hex, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function _linearize(c) {
+  c /= 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function _luminance(hex) {
+  const [r, g, b] = _hexToRgb(hex);
+  return 0.2126 * _linearize(r) + 0.7152 * _linearize(g) + 0.0722 * _linearize(b);
+}
+
+function contrastRatio(hex1, hex2) {
+  const l1 = _luminance(hex1);
+  const l2 = _luminance(hex2);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+/**
+ * Pick a foreground color that meets WCAG AA against `bgHex`.
+ *
+ * Tries the theme's two extreme neutrals (darkest text / lightest text)
+ * first and returns whichever clears AA. If both somehow fail (very
+ * mid-luminance background), it walks the neutral scale outward from each
+ * extreme to the nearest tier that passes, then falls back to whichever
+ * extreme has the higher ratio (best effort). The background is never
+ * altered — only the foreground is chosen.
+ *
+ * @param {string} bgHex            - background color
+ * @param {string} darkFg           - the theme's darkest neutral (e.g. n.scale.get(950))
+ * @param {string} lightFg          - the theme's lightest neutral (e.g. n.scale.get(0))
+ * @param {Map<number,string>} neutralScale - full neutral scale for tier fallback
+ * @returns {string} foreground hex that best meets AA
+ */
+function pickOnColor(bgHex, darkFg, lightFg, neutralScale) {
+  const darkR = contrastRatio(darkFg, bgHex);
+  const lightR = contrastRatio(lightFg, bgHex);
+
+  // Prefer whichever extreme passes; if both pass, prefer the higher ratio.
+  const darkPass = darkR >= AA_NORMAL;
+  const lightPass = lightR >= AA_NORMAL;
+  if (darkPass && lightPass) return darkR >= lightR ? darkFg : lightFg;
+  if (darkPass) return darkFg;
+  if (lightPass) return lightFg;
+
+  // Neither extreme clears AA (rare, mid-luminance bg). Walk the scale toward
+  // the passing direction: darker tiers (1000→600) for dark text, lighter tiers
+  // (0→400) for light text. Return the first tier that clears AA.
+  const darkTiers = [1000, 950, 900, 800, 700, 600];
+  const lightTiers = [0, 50, 100, 200, 300, 400];
+  for (const step of darkTiers) {
+    const hex = neutralScale.get(step);
+    if (hex && contrastRatio(hex, bgHex) >= AA_NORMAL) return hex;
+  }
+  for (const step of lightTiers) {
+    const hex = neutralScale.get(step);
+    if (hex && contrastRatio(hex, bgHex) >= AA_NORMAL) return hex;
+  }
+
+  // Best effort: the higher-contrast extreme.
+  return darkR >= lightR ? darkFg : lightFg;
+}
+
 /**
  * Generate light and dark semantic token maps from a palette.
  *
@@ -41,6 +117,28 @@ export function generateTheme(paletteResult, brandIndex = 0) {
   const n = neutral;
   const s = status;
 
+  // AA-correct foreground selection. Extremes drawn from the theme's own
+  // neutral scale so on-colors stay tonally on-brand (not pure #000/#fff).
+  const darkFg  = n.scale.get(950);
+  const lightFg = n.scale.get(0);
+  const onColor = bgHex => pickOnColor(bgHex, darkFg, lightFg, n.scale);
+
+  // Status + primary backgrounds (brand-derived — never altered here).
+  const lightStatusBg = {
+    success: s.success.scale.get(600),
+    warning: s.warning.scale.get(500),
+    danger:  s.danger.scale.get(600),
+    info:    s.info.scale.get(600),
+  };
+  const darkStatusBg = {
+    success: s.success.scale.get(600),
+    warning: s.warning.scale.get(600),
+    danger:  s.danger.scale.get(600),
+    info:    s.info.scale.get(600),
+  };
+  const primaryBgLight = primary.scale.get(500);
+  const primaryBgDark  = primary.scale.get(500);
+
   const light = {
     // Surface
     '--dvfy-surface-page':      n.scale.get(0),
@@ -65,11 +163,12 @@ export function generateTheme(paletteResult, brandIndex = 0) {
     '--dvfy-border-focus':      primary.scale.get(500),
 
     // Primary — 500 is the user's actual brand color
-    '--dvfy-primary-bg':        primary.scale.get(500),
+    '--dvfy-primary-bg':        primaryBgLight,
     '--dvfy-primary-bg-hover':  primary.scale.get(600),
     '--dvfy-primary-bg-active': primary.scale.get(700),
     '--dvfy-primary-bg-subtle': primary.scale.get(50),
-    '--dvfy-primary-text':      n.scale.get(950),
+    // AA-correct text on the primary CTA, measured vs the actual brand bg.
+    '--dvfy-primary-text':      onColor(primaryBgLight),
     '--dvfy-primary-border':    primary.scale.get(500),
 
     // Accent
@@ -113,11 +212,12 @@ export function generateTheme(paletteResult, brandIndex = 0) {
     '--dvfy-input-placeholder': n.scale.get(400),
     '--dvfy-input-error':       s.danger.scale.get(500),
 
-    // Status on (text color on solid status backgrounds)
-    '--dvfy-on-success':        n.scale.get(950),
-    '--dvfy-on-warning':        n.scale.get(950),
-    '--dvfy-on-danger':         n.scale.get(0),
-    '--dvfy-on-info':           n.scale.get(950),
+    // Status on (text color on solid status backgrounds) — AA-correct by
+    // construction: foreground chosen by measured contrast vs each status bg.
+    '--dvfy-on-success':        onColor(lightStatusBg.success),
+    '--dvfy-on-warning':        onColor(lightStatusBg.warning),
+    '--dvfy-on-danger':         onColor(lightStatusBg.danger),
+    '--dvfy-on-info':           onColor(lightStatusBg.info),
 
     // Tooltip
     '--dvfy-tooltip-bg':        n.scale.get(700),
@@ -149,12 +249,13 @@ export function generateTheme(paletteResult, brandIndex = 0) {
     '--dvfy-border-muted':      n.scale.get(800),
     '--dvfy-border-focus':      primary.scale.get(400),
 
-    // Primary
-    '--dvfy-primary-bg':        primary.scale.get(500),
+    // Primary — dark-mode CTA button (highest-stakes pair). Text is chosen by
+    // measured contrast vs the actual brand bg so the dark CTA always reads.
+    '--dvfy-primary-bg':        primaryBgDark,
     '--dvfy-primary-bg-hover':  primary.scale.get(400),
     '--dvfy-primary-bg-active': primary.scale.get(300),
     '--dvfy-primary-bg-subtle': primary.scale.get(950),
-    '--dvfy-primary-text':      n.scale.get(950),
+    '--dvfy-primary-text':      onColor(primaryBgDark),
     '--dvfy-primary-border':    primary.scale.get(500),
 
     // Accent
@@ -198,11 +299,12 @@ export function generateTheme(paletteResult, brandIndex = 0) {
     '--dvfy-input-placeholder': n.scale.get(500),
     '--dvfy-input-error':       s.danger.scale.get(400),
 
-    // Status on (text color on solid status backgrounds)
-    '--dvfy-on-success':        n.scale.get(950),
-    '--dvfy-on-warning':        n.scale.get(950),
-    '--dvfy-on-danger':         n.scale.get(0),
-    '--dvfy-on-info':           n.scale.get(950),
+    // Status on (text color on solid status backgrounds) — AA-correct by
+    // construction: foreground chosen by measured contrast vs each status bg.
+    '--dvfy-on-success':        onColor(darkStatusBg.success),
+    '--dvfy-on-warning':        onColor(darkStatusBg.warning),
+    '--dvfy-on-danger':         onColor(darkStatusBg.danger),
+    '--dvfy-on-info':           onColor(darkStatusBg.info),
 
     // Tooltip
     '--dvfy-tooltip-bg':        n.scale.get(200),

--- a/tokens/themes/renting-ideal.brand.json
+++ b/tokens/themes/renting-ideal.brand.json
@@ -1,0 +1,16 @@
+{
+  "name": "renting-ideal",
+  "label": "Renting Ideal",
+  "tagline": "Tu asesor de confianza",
+  "intent": "Trustworthy, impartial, calm car-renting advisor. The sage/forest green reads as trust, calm, and impartiality (the honest trust strip is 'Impartial · Transparent · Free').",
+  "seed": {
+    "brandColors": ["#5A7E65"],
+    "brandIndex": 0,
+    "supportCount": 6,
+    "prefix": "--brand"
+  },
+  "provenance": "Faithful port of rueda's existing sage-green brand (was a local fork in projects/rueda/static/css/tokens/themes/rueda.css, generated from brand #5A7E65). Lifted into @devify/ui as a first-class named theme per the Tool Interface Contracts standard (brands are author-time artifacts, consumed by name). devify-ui#366.",
+  "generator": "tokens/theme-generator.js generateTheme(generatePalette(seed), brandIndex)",
+  "outputs": ["renting-ideal.css"],
+  "readonly": true
+}

--- a/tokens/themes/renting-ideal.css
+++ b/tokens/themes/renting-ideal.css
@@ -1,0 +1,143 @@
+/*
+ * @devify/ui — Renting Ideal Theme (renting-ideal)
+ *
+ * "Renting Ideal — Tu asesor de confianza".
+ * Generated, read-only. DO NOT hand-edit.
+ * Regenerate: node scripts/generate-named-theme.mjs renting-ideal
+ * Source of truth: tokens/themes/renting-ideal.brand.json (seed #5A7E65).
+ *
+ * Faithful port of rueda's existing sage-green brand (was a local fork in projects/rueda/static/css/tokens/themes/rueda.css, generated from brand #5A7E65). Lifted into @devify/ui as a first-class named theme per the Tool Interface Contracts standard (brands are author-time artifacts, consumed by name). devify-ui#366.
+ *
+ * Activate with data-theme="renting-ideal" (light) or data-theme="renting-ideal-dark" (dark).
+ * Full semantic layer (light != dark), self-contained concrete values.
+ */
+
+[data-theme="renting-ideal"] {
+  --dvfy-surface-page: #fdfdfd;
+  --dvfy-surface-raised: #fdfdfd;
+  --dvfy-surface-overlay: #fdfdfd;
+  --dvfy-surface-sunken: #f1f7f3;
+  --dvfy-surface-muted: #e5e6e5;
+  --dvfy-text-primary: #202020;
+  --dvfy-text-secondary: #4e4f4e;
+  --dvfy-text-muted: #878a88;
+  --dvfy-text-disabled: #878a88;
+  --dvfy-text-inverse: #fdfdfd;
+  --dvfy-text-link: #3e4741;
+  --dvfy-text-link-hover: #303331;
+  --dvfy-border-default: #cdcfce;
+  --dvfy-border-strong: #afb1af;
+  --dvfy-border-muted: #e1eae4;
+  --dvfy-border-focus: #5a7e65;
+  --dvfy-primary-bg: #5a7e65;
+  --dvfy-primary-bg-hover: #4e6153;
+  --dvfy-primary-bg-active: #3e4741;
+  --dvfy-primary-bg-subtle: #f1f7f3;
+  --dvfy-primary-text: #0f0f0f;
+  --dvfy-primary-border: #5a7e65;
+  --dvfy-accent-bg: #7b6c8f;
+  --dvfy-accent-bg-hover: #5f576b;
+  --dvfy-accent-bg-subtle: #f6f4f9;
+  --dvfy-accent-text: #46424b;
+  --dvfy-accent-border: #d7cfe3;
+  --dvfy-success-bg: #536052;
+  --dvfy-success-bg-subtle: #f2f6f2;
+  --dvfy-success-text: #313331;
+  --dvfy-success-border: #cad8ca;
+  --dvfy-warning-bg: #866f55;
+  --dvfy-warning-bg-subtle: #f8f4f0;
+  --dvfy-warning-text: #232322;
+  --dvfy-warning-border: #ded1c3;
+  --dvfy-danger-bg: #6a5654;
+  --dvfy-danger-bg-subtle: #f9f3f3;
+  --dvfy-danger-text: #343131;
+  --dvfy-danger-border: #e3cdcb;
+  --dvfy-info-bg: #4c5f68;
+  --dvfy-info-bg-subtle: #f1f6f9;
+  --dvfy-info-text: #303334;
+  --dvfy-info-border: #c4d7e0;
+  --dvfy-hover-bg: #e5e6e5;
+  --dvfy-active-bg: #cdcfce;
+  --dvfy-selected-bg: #f1f7f3;
+  --dvfy-disabled-bg: #e5e6e5;
+  --dvfy-disabled-text: #878a88;
+  --dvfy-ring-color: #5a7e65;
+  --dvfy-input-bg: #fdfdfd;
+  --dvfy-input-border: #afb1af;
+  --dvfy-input-border-hover: #878a88;
+  --dvfy-input-border-focus: #5a7e65;
+  --dvfy-input-placeholder: #878a88;
+  --dvfy-input-error: #8e6966;
+  --dvfy-on-success: #0f0f0f;
+  --dvfy-on-warning: #0f0f0f;
+  --dvfy-on-danger: #fdfdfd;
+  --dvfy-on-info: #0f0f0f;
+  --dvfy-tooltip-bg: #3b3c3b;
+  --dvfy-tooltip-text: #e5e6e5;
+  --dvfy-tooltip-border: #4e4f4e;
+}
+
+[data-theme="renting-ideal-dark"] {
+  --dvfy-surface-page: #0f0f0f;
+  --dvfy-surface-raised: #202020;
+  --dvfy-surface-overlay: #2c2d2c;
+  --dvfy-surface-sunken: #000000;
+  --dvfy-surface-muted: #2c2d2c;
+  --dvfy-text-primary: #f5f5f5;
+  --dvfy-text-secondary: #afb1af;
+  --dvfy-text-muted: #616462;
+  --dvfy-text-disabled: #4e4f4e;
+  --dvfy-text-inverse: #202020;
+  --dvfy-text-link: #7ca187;
+  --dvfy-text-link-hover: #a3c2ab;
+  --dvfy-border-default: #3b3c3b;
+  --dvfy-border-strong: #4e4f4e;
+  --dvfy-border-muted: #2c2d2c;
+  --dvfy-border-focus: #7ca187;
+  --dvfy-primary-bg: #5a7e65;
+  --dvfy-primary-bg-hover: #7ca187;
+  --dvfy-primary-bg-active: #a3c2ab;
+  --dvfy-primary-bg-subtle: #0f0f0f;
+  --dvfy-primary-text: #0f0f0f;
+  --dvfy-primary-border: #5a7e65;
+  --dvfy-accent-bg: #7b6c8f;
+  --dvfy-accent-bg-hover: #9e8eb3;
+  --dvfy-accent-bg-subtle: #0f0f10;
+  --dvfy-accent-text: #bfb2d2;
+  --dvfy-accent-border: #46424b;
+  --dvfy-success-bg: #536052;
+  --dvfy-success-bg-subtle: #0f0f0f;
+  --dvfy-success-text: #aac0aa;
+  --dvfy-success-border: #404640;
+  --dvfy-warning-bg: #66594b;
+  --dvfy-warning-bg-subtle: #100f0f;
+  --dvfy-warning-text: #cab59e;
+  --dvfy-warning-border: #49433d;
+  --dvfy-danger-bg: #6a5654;
+  --dvfy-danger-bg-subtle: #100f0f;
+  --dvfy-danger-text: #d1afac;
+  --dvfy-danger-border: #4b4241;
+  --dvfy-info-bg: #4c5f68;
+  --dvfy-info-bg-subtle: #0f0f10;
+  --dvfy-info-text: #a0bece;
+  --dvfy-info-border: #3e464a;
+  --dvfy-hover-bg: #2c2d2c;
+  --dvfy-active-bg: #3b3c3b;
+  --dvfy-selected-bg: #0f0f0f;
+  --dvfy-disabled-bg: #2c2d2c;
+  --dvfy-disabled-text: #4e4f4e;
+  --dvfy-ring-color: #7ca187;
+  --dvfy-input-bg: #202020;
+  --dvfy-input-border: #4e4f4e;
+  --dvfy-input-border-hover: #616462;
+  --dvfy-input-border-focus: #7ca187;
+  --dvfy-input-placeholder: #616462;
+  --dvfy-input-error: #b28b88;
+  --dvfy-on-success: #0f0f0f;
+  --dvfy-on-warning: #0f0f0f;
+  --dvfy-on-danger: #fdfdfd;
+  --dvfy-on-info: #0f0f0f;
+  --dvfy-tooltip-bg: #cdcfce;
+  --dvfy-tooltip-text: #202020;
+  --dvfy-tooltip-border: #afb1af;
+}

--- a/tokens/themes/renting-ideal.css
+++ b/tokens/themes/renting-ideal.css
@@ -33,7 +33,7 @@
   --dvfy-primary-bg-hover: #4e6153;
   --dvfy-primary-bg-active: #3e4741;
   --dvfy-primary-bg-subtle: #f1f7f3;
-  --dvfy-primary-text: #0f0f0f;
+  --dvfy-primary-text: #000000;
   --dvfy-primary-border: #5a7e65;
   --dvfy-accent-bg: #7b6c8f;
   --dvfy-accent-bg-hover: #5f576b;
@@ -68,10 +68,10 @@
   --dvfy-input-border-focus: #5a7e65;
   --dvfy-input-placeholder: #878a88;
   --dvfy-input-error: #8e6966;
-  --dvfy-on-success: #0f0f0f;
-  --dvfy-on-warning: #0f0f0f;
+  --dvfy-on-success: #fdfdfd;
+  --dvfy-on-warning: #fdfdfd;
   --dvfy-on-danger: #fdfdfd;
-  --dvfy-on-info: #0f0f0f;
+  --dvfy-on-info: #fdfdfd;
   --dvfy-tooltip-bg: #3b3c3b;
   --dvfy-tooltip-text: #e5e6e5;
   --dvfy-tooltip-border: #4e4f4e;
@@ -98,7 +98,7 @@
   --dvfy-primary-bg-hover: #7ca187;
   --dvfy-primary-bg-active: #a3c2ab;
   --dvfy-primary-bg-subtle: #0f0f0f;
-  --dvfy-primary-text: #0f0f0f;
+  --dvfy-primary-text: #000000;
   --dvfy-primary-border: #5a7e65;
   --dvfy-accent-bg: #7b6c8f;
   --dvfy-accent-bg-hover: #9e8eb3;
@@ -133,10 +133,10 @@
   --dvfy-input-border-focus: #7ca187;
   --dvfy-input-placeholder: #616462;
   --dvfy-input-error: #b28b88;
-  --dvfy-on-success: #0f0f0f;
-  --dvfy-on-warning: #0f0f0f;
+  --dvfy-on-success: #fdfdfd;
+  --dvfy-on-warning: #fdfdfd;
   --dvfy-on-danger: #fdfdfd;
-  --dvfy-on-info: #0f0f0f;
+  --dvfy-on-info: #fdfdfd;
   --dvfy-tooltip-bg: #cdcfce;
   --dvfy-tooltip-text: #202020;
   --dvfy-tooltip-border: #afb1af;


### PR DESCRIPTION
Closes part of **devify-ui#366** (LP-Factory POC gap G1) — authors the **Renting Ideal** brand as a first-class, named, versioned, read-only `@devify/ui` theme — **and** fixes the root-cause WCAG AA contrast bug it surfaced in the shared theme generator (**Closes #369**).

This PR now has two coupled parts (per the LP-Factory decision to land the brand PR together with the root-cause fix):
1. **Faithful port** — Renting Ideal as a named theme.
2. **Root-cause AA fix** — `theme-generator.js` now derives on-status + primary text by measured contrast, so **every** seed produces an AA-passing theme.

---

## Part 1 — a faithful port, not a redesign
rueda already has its sage/forest-green identity, but it lived as a **local fork** (`projects/rueda/static/css/tokens/themes/rueda.css`, seed `#5A7E65`, via a forked local theme-generator) — exactly the per-project styling drift the Tool Interface Contracts standard forbids, and the anti-pattern that broke rueda's LP. This lifts that existing brand into `@devify/ui` so rueda can later consume it **by name** (`data-theme="renting-ideal"`).

The generated **brand hues are byte-identical** to the rueda fork — confirmed by reproducing the seed through `@devify/ui`'s own `generatePalette({brandColors:['#5A7E65']}) -> generateTheme()` (the same mechanism that produces devify-cyan / devify-pink).

### What landed (port)
- **`tokens/themes/renting-ideal.brand.json`** — committed seed/brief (source of truth: seed `#5A7E65`, intent, provenance).
- **`tokens/themes/renting-ideal.css`** — generated, **read-only**: full semantic layer for `renting-ideal` (light) + `renting-ideal-dark` (dark).
- **`scripts/generate-named-theme.mjs`** — regenerates from the brief; `--check` mode guards against drift / hand-edits. `npm run themes:gen` / `themes:check`.
- **catalog + README** — register `renting-ideal` as a selectable named theme.

---

## Part 2 — root-cause AA fix (Closes #369)
The faithful port inherited **4 WCAG AA failures** — `--dvfy-on-success/-warning/-info` (low-contrast text on medium-dark status badges) and the **dark-mode `--dvfy-primary-text` / `--dvfy-primary-bg` pair** (the CTA button in dark mode, the highest-stakes one). These come from the **shared `theme-generator.js`** picking on-color/text from a *fixed* near-black/near-white assumption — **the original rueda fork carried the same failures**, so it is a property of the generator, not the brand.

### The fix — AA-correct by construction
- New **`pickOnColor()`** in `theme-generator.js`: chooses the foreground by **measured contrast ratio against the actual background** (the theme's darkest/lightest neutral, or the nearest passing tier as fallback). **The brand background hue is never altered** — only the foreground/on-color moves. No desaturation or hue shift of the green/cyan/pink.
- Applied to `--dvfy-on-success/-warning/-danger/-info` and the `--dvfy-primary-text` / `--dvfy-primary-bg` pair, **light and dark**.
- **`renting-ideal.css` regenerated** — only on-color/text tokens change; every brand hue is byte-identical (verified by diff).
- **`renting-ideal` + `renting-ideal-dark` registered in the gating `check-contrast.js`**; the temporary exclusion NOTE is removed.

This also satisfies LP-Factory **G7** (variant-admission gate): the generator no longer emits AA-failing tokens, so a theme can't fail that gate by construction.

---

## Verification (Iron Law — real browser, not just unit/static)
- **`contrast:ci` green for all 8 themes** — `light`, `dark`, `devify-cyan(+dark)`, `devify-pink(+dark)`, `renting-ideal(+dark)`: **120 pass / 0 fail**.
- `lint` (js/css/tokens/dvfy-pref) green; `themes:check` (drift guard) green; **1428 unit tests pass**.
- **Real browser (chromium, served bundle + app base layer + `data-theme` on `<html>`):** the four status badges and the **dark-mode CTA** are computed-legible (all ≥4.5:1) in both light and dark; the sage brand backgrounds (`--dvfy-primary-bg` = `#5a7e65`, all status bgs) are **identical before vs after** the fix — confirmed by computed-style assertions and before/after screenshots of the changed surfaces.

The status-bg / primary-bg hues are unchanged; only the text/on-color flips to whatever meets AA (white on the dark sage badges, black on the sage CTA).

Does NOT touch rueda's repo (swapping rueda to consume the named theme is Session 3).

Refs devify-ui#366 · Closes devify-ui#369
