### PR TITLE
feat(composition): page-composition primitives — LP-Factory N1 / G2 producer (#372)

### DIFF
--- a/components/dvfy-grid.js
+++ b/components/dvfy-grid.js
@@ -1,0 +1,95 @@
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-grid> — Responsive equal-column grid.
+ *
+ * Replaces invented `dvfy-grid dvfy-grid-cols-* dvfy-grid-cols-md-* dvfy-gap-*`
+ * utility classes. Collapses to a single column below the md breakpoint via a
+ * container query (parent width, not viewport) — matching the library's
+ * container-query responsive convention.
+ *
+ * Attributes:
+ *   cols: 1 | 2 | 3 | 4   — equal columns at full width (default 1)
+ *   min:  <length>        — when set, uses auto-fit tracks of min(<length>) instead
+ *                           of a fixed column count (e.g. min="16rem")
+ *   gap:  sm | md | lg    — gutter between cells (--dvfy-space-*; default md)
+ *
+ * Usage:
+ *   <dvfy-grid cols="3" gap="lg"> <dvfy-card-glow padded>…</dvfy-card-glow> … </dvfy-grid>
+ *   <dvfy-grid min="16rem" gap="md"> …auto-fitting cards… </dvfy-grid>
+ */
+
+const STYLES = `
+dvfy-grid {
+  display: grid;
+  box-sizing: border-box;
+  container-type: inline-size;
+  /* default gap = md */
+  gap: var(--dvfy-space-6);
+  grid-template-columns: 1fr;
+}
+
+/* Gap scale */
+dvfy-grid[gap="sm"] { gap: var(--dvfy-space-3); }
+dvfy-grid[gap="md"] { gap: var(--dvfy-space-6); }
+dvfy-grid[gap="lg"] { gap: var(--dvfy-space-10); }
+
+/* Fixed equal columns (>= md). Below md they collapse to 1 column. */
+@container (min-width: 48rem) {
+  dvfy-grid[cols="2"] { grid-template-columns: repeat(2, 1fr); }
+  dvfy-grid[cols="3"] { grid-template-columns: repeat(3, 1fr); }
+  dvfy-grid[cols="4"] { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* Auto-fit tracks — when min is set, ignore the cols count and fill responsively.
+   --dvfy-grid-min is the consumer-set minimum track size. */
+dvfy-grid[min] {
+  grid-template-columns: repeat(auto-fit, minmax(min(var(--dvfy-grid-min, 16rem), 100%), 1fr));
+}
+`;
+
+/**
+ * Responsive equal-column grid that collapses to one column below the md breakpoint.
+ *
+ * @element dvfy-grid
+ *
+ * @attr {string} cols - Equal columns at full width: 1 | 2 | 3 | 4 (default 1)
+ * @attr {string} min - Auto-fit track minimum length (e.g. "16rem"); overrides cols when set
+ * @attr {string} gap - Gutter between cells: sm | md | lg (default md)
+ *
+ * @slot - Grid cells
+ *
+ * @cssprop {length} --dvfy-grid-min - Minimum track size for auto-fit mode (default 16rem)
+ *
+ * @example
+ * <dvfy-grid cols="3" gap="lg">
+ *   <dvfy-card-glow padded>One</dvfy-card-glow>
+ *   <dvfy-card-glow padded>Two</dvfy-card-glow>
+ *   <dvfy-card-glow padded>Three</dvfy-card-glow>
+ * </dvfy-grid>
+ */
+class DvfyGrid extends HTMLElement {
+  connectedCallback() {
+    injectStyles('dvfy-grid', STYLES);
+    this.#applyMin();
+  }
+
+  static get observedAttributes() { return ['min']; }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.#applyMin();
+  }
+
+  // Mirror the `min` attribute into the --dvfy-grid-min custom property so the
+  // auto-fit track can consume it (attr values can't be read inside CSS minmax()).
+  #applyMin() {
+    const min = this.getAttribute('min');
+    if (min) {
+      this.style.setProperty('--dvfy-grid-min', min);
+    } else {
+      this.style.removeProperty('--dvfy-grid-min');
+    }
+  }
+}
+
+customElements.define('dvfy-grid', DvfyGrid);

--- a/components/dvfy-grid.test.js
+++ b/components/dvfy-grid.test.js
@@ -1,0 +1,33 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-grid.js';
+
+describe('dvfy-grid', () => {
+  it('renders slotted cells', async () => {
+    const el = await fixture(html`
+      <dvfy-grid cols="3"><div>a</div><div>b</div><div>c</div></dvfy-grid>
+    `);
+    expect(el.children.length).to.equal(3);
+  });
+
+  it('uses display:grid', async () => {
+    const el = await fixture(html`<dvfy-grid cols="2"><div>a</div></dvfy-grid>`);
+    expect(getComputedStyle(el).display).to.equal('grid');
+  });
+
+  it('accepts cols and gap attributes', async () => {
+    const el = await fixture(html`<dvfy-grid cols="4" gap="lg"><div>a</div></dvfy-grid>`);
+    expect(el.getAttribute('cols')).to.equal('4');
+    expect(el.getAttribute('gap')).to.equal('lg');
+  });
+
+  it('mirrors the min attribute into --dvfy-grid-min', async () => {
+    const el = await fixture(html`<dvfy-grid min="16rem"><div>a</div></dvfy-grid>`);
+    expect(el.style.getPropertyValue('--dvfy-grid-min')).to.equal('16rem');
+  });
+
+  it('clears --dvfy-grid-min when min is removed', async () => {
+    const el = await fixture(html`<dvfy-grid min="16rem"><div>a</div></dvfy-grid>`);
+    el.removeAttribute('min');
+    expect(el.style.getPropertyValue('--dvfy-grid-min')).to.equal('');
+  });
+});

--- a/components/dvfy-heading.js
+++ b/components/dvfy-heading.js
@@ -1,0 +1,114 @@
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-heading> — Semantic heading bound to the --dvfy-type-h*-* role tokens.
+ *
+ * Replaces invented `dvfy-heading-1 / -2 / -3` utility classes. The level attribute
+ * selects BOTH the visual role token and the underlying semantic tag — it renders a
+ * real <h1>/<h2>/<h3> in the light DOM so the page keeps a correct heading outline
+ * (SEO single-<h1>, a11y landmarks). Typography flows entirely through
+ * --dvfy-type-h{level}-* tokens, so a theme can restyle every heading globally.
+ *
+ * Attributes:
+ *   level: 1 | 2 | 3   — heading level / role token (default 2)
+ *
+ * Usage:
+ *   <dvfy-heading level="1">Tu mejor renting</dvfy-heading>
+ *   <dvfy-heading level="2">Cómo funciona</dvfy-heading>
+ */
+
+const STYLES = `
+dvfy-heading {
+  display: block;
+  color: var(--dvfy-text-primary);
+  /* default = h2 */
+  font-family: var(--dvfy-type-h2-family);
+  font-size: var(--dvfy-type-h2-size);
+  font-weight: var(--dvfy-type-h2-weight);
+  line-height: var(--dvfy-type-h2-leading);
+  letter-spacing: var(--dvfy-type-h2-tracking);
+}
+
+dvfy-heading > h1,
+dvfy-heading > h2,
+dvfy-heading > h3 {
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+}
+
+dvfy-heading[level="1"] {
+  font-family: var(--dvfy-type-h1-family);
+  font-size: var(--dvfy-type-h1-size);
+  font-weight: var(--dvfy-type-h1-weight);
+  line-height: var(--dvfy-type-h1-leading);
+  letter-spacing: var(--dvfy-type-h1-tracking);
+}
+dvfy-heading[level="2"] {
+  font-family: var(--dvfy-type-h2-family);
+  font-size: var(--dvfy-type-h2-size);
+  font-weight: var(--dvfy-type-h2-weight);
+  line-height: var(--dvfy-type-h2-leading);
+  letter-spacing: var(--dvfy-type-h2-tracking);
+}
+dvfy-heading[level="3"] {
+  font-family: var(--dvfy-type-h3-family);
+  font-size: var(--dvfy-type-h3-size);
+  font-weight: var(--dvfy-type-h3-weight);
+  line-height: var(--dvfy-type-h3-leading);
+  letter-spacing: var(--dvfy-type-h3-tracking);
+}
+`;
+
+const VALID_LEVELS = new Set(['1', '2', '3']);
+
+/**
+ * Semantic heading bound to the --dvfy-type-h{level}-* role tokens; renders a real
+ * <h1>/<h2>/<h3> so the document keeps a correct heading outline.
+ *
+ * @element dvfy-heading
+ *
+ * @attr {string} level - Heading level / role token: 1 | 2 | 3 (default 2)
+ *
+ * @slot - Heading text
+ *
+ * @cssprop {*} --dvfy-type-h1-size - H1 font size (and family/weight/leading/tracking siblings)
+ * @cssprop {*} --dvfy-type-h2-size - H2 font size (and siblings)
+ * @cssprop {*} --dvfy-type-h3-size - H3 font size (and siblings)
+ *
+ * @example
+ * <dvfy-heading level="1">Tu mejor renting</dvfy-heading>
+ */
+class DvfyHeading extends HTMLElement {
+  connectedCallback() {
+    injectStyles('dvfy-heading', STYLES);
+    this.#render();
+  }
+
+  static get observedAttributes() { return ['level']; }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.#render();
+  }
+
+  #render() {
+    const raw = this.getAttribute('level');
+    const level = VALID_LEVELS.has(raw) ? raw : '2';
+    const tag = `h${level}`;
+
+    // Already wrapping the right tag? Leave the existing text untouched.
+    const existing = this.firstElementChild;
+    if (existing && existing.tagName.toLowerCase() === tag &&
+        this.childNodes.length === 1) {
+      return;
+    }
+
+    // Move all current content (text + inline markup) into the semantic tag.
+    const heading = document.createElement(tag);
+    while (this.firstChild) heading.appendChild(this.firstChild);
+    this.appendChild(heading);
+  }
+}
+
+customElements.define('dvfy-heading', DvfyHeading);

--- a/components/dvfy-heading.test.js
+++ b/components/dvfy-heading.test.js
@@ -1,0 +1,31 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-heading.js';
+
+describe('dvfy-heading', () => {
+  it('renders a real <h2> by default and keeps the text', async () => {
+    const el = await fixture(html`<dvfy-heading>Cómo funciona</dvfy-heading>`);
+    const h = el.firstElementChild;
+    expect(h.tagName.toLowerCase()).to.equal('h2');
+    expect(h.textContent).to.equal('Cómo funciona');
+  });
+
+  it('renders an <h1> for level=1 (SEO single-h1 target)', async () => {
+    const el = await fixture(html`<dvfy-heading level="1">Title</dvfy-heading>`);
+    expect(el.firstElementChild.tagName.toLowerCase()).to.equal('h1');
+  });
+
+  it('renders an <h3> for level=3', async () => {
+    const el = await fixture(html`<dvfy-heading level="3">Sub</dvfy-heading>`);
+    expect(el.firstElementChild.tagName.toLowerCase()).to.equal('h3');
+  });
+
+  it('falls back to <h2> for an invalid level', async () => {
+    const el = await fixture(html`<dvfy-heading level="9">x</dvfy-heading>`);
+    expect(el.firstElementChild.tagName.toLowerCase()).to.equal('h2');
+  });
+
+  it('produces exactly one semantic heading element (no double-wrap)', async () => {
+    const el = await fixture(html`<dvfy-heading level="2">Once</dvfy-heading>`);
+    expect(el.querySelectorAll('h1,h2,h3').length).to.equal(1);
+  });
+});

--- a/components/dvfy-page-section.js
+++ b/components/dvfy-page-section.js
@@ -1,0 +1,92 @@
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-page-section> — Page vertical-rhythm wrapper for landing-page sections.
+ *
+ * The composition primitive that replaces invented `dvfy-py-*` / `dvfy-text-center`
+ * utility classes on a page `<section>`. One §8 playbook slot = one page-section.
+ *
+ * NOTE: this is NOT <dvfy-section> (the collapsible disclosure widget) — that name
+ * is taken. Page sections use <dvfy-page-section>.
+ *
+ * Attributes:
+ *   padding: md | lg | xl   — vertical rhythm (fluid clamp on --dvfy-space-*; default lg)
+ *   align:   left | center  — content alignment (default left)
+ *   tone:    default | muted | brand — background tone (default default)
+ *   width:   prose | wide | full — inner content rail max-width (default wide)
+ *
+ * Usage:
+ *   <dvfy-page-section tone="muted" padding="xl" align="center" width="wide">
+ *     <dvfy-heading level="2">How it works</dvfy-heading>
+ *     <dvfy-grid cols="3" gap="lg"> ... </dvfy-grid>
+ *   </dvfy-page-section>
+ */
+
+const STYLES = `
+dvfy-page-section {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  container-type: inline-size;
+  background: var(--dvfy-surface-page);
+  color: var(--dvfy-text-primary);
+  font-family: var(--dvfy-font-sans);
+  /* default padding = lg */
+  padding-block: clamp(var(--dvfy-space-10), 5vw, var(--dvfy-space-16));
+  padding-inline: clamp(var(--dvfy-space-5), 3vw, var(--dvfy-space-8));
+}
+
+/* Padding scale — fluid clamp, same pattern as dvfy-section-hero */
+dvfy-page-section[padding="md"] { padding-block: clamp(var(--dvfy-space-8),  4vw, var(--dvfy-space-12)); }
+dvfy-page-section[padding="lg"] { padding-block: clamp(var(--dvfy-space-10), 5vw, var(--dvfy-space-16)); }
+dvfy-page-section[padding="xl"] { padding-block: clamp(var(--dvfy-space-12), 6vw, var(--dvfy-space-20)); }
+
+/* Tone */
+dvfy-page-section[tone="muted"] { background: var(--dvfy-surface-muted); }
+dvfy-page-section[tone="brand"] { background: var(--dvfy-primary-bg-subtle); }
+
+/* Inner content rail — centers the section body, caps width */
+dvfy-page-section > * {
+  margin-inline: auto;
+  box-sizing: border-box;
+}
+
+/* Width rail */
+dvfy-page-section > * { max-width: var(--dvfy-container-6xl); }            /* default = wide */
+dvfy-page-section[width="prose"] > * { max-width: var(--dvfy-prose-lg); }
+dvfy-page-section[width="wide"]  > * { max-width: var(--dvfy-container-6xl); }
+dvfy-page-section[width="full"]  > * { max-width: none; }
+
+/* Align */
+dvfy-page-section[align="center"] { text-align: center; }
+dvfy-page-section[align="left"]   { text-align: left; }
+`;
+
+/**
+ * Page vertical-rhythm wrapper for landing-page sections.
+ *
+ * @element dvfy-page-section
+ *
+ * @attr {string} padding - Vertical rhythm scale: md | lg | xl (default lg)
+ * @attr {string} align - Content alignment: left | center (default left)
+ * @attr {string} tone - Background tone: default | muted | brand (default default)
+ * @attr {string} width - Inner content rail: prose | wide | full (default wide)
+ *
+ * @slot - Section content
+ *
+ * @cssprop {color} --dvfy-surface-page - Default tone background
+ * @cssprop {color} --dvfy-surface-muted - Muted tone background
+ * @cssprop {color} --dvfy-primary-bg-subtle - Brand tone background
+ *
+ * @example
+ * <dvfy-page-section tone="muted" padding="xl" align="center">
+ *   <dvfy-heading level="2">How it works</dvfy-heading>
+ * </dvfy-page-section>
+ */
+class DvfyPageSection extends HTMLElement {
+  connectedCallback() {
+    injectStyles('dvfy-page-section', STYLES);
+  }
+}
+
+customElements.define('dvfy-page-section', DvfyPageSection);

--- a/components/dvfy-page-section.test.js
+++ b/components/dvfy-page-section.test.js
@@ -1,0 +1,33 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-page-section.js';
+
+describe('dvfy-page-section', () => {
+  it('renders slotted content', async () => {
+    const el = await fixture(html`
+      <dvfy-page-section><h2>Section title</h2></dvfy-page-section>
+    `);
+    expect(el.querySelector('h2').textContent).to.equal('Section title');
+  });
+
+  it('is defined as a custom element', () => {
+    expect(customElements.get('dvfy-page-section')).to.exist;
+  });
+
+  it('accepts padding / align / tone / width attributes', async () => {
+    const el = await fixture(html`
+      <dvfy-page-section padding="xl" align="center" tone="muted" width="prose">
+        content
+      </dvfy-page-section>
+    `);
+    expect(el.getAttribute('padding')).to.equal('xl');
+    expect(el.getAttribute('align')).to.equal('center');
+    expect(el.getAttribute('tone')).to.equal('muted');
+    expect(el.getAttribute('width')).to.equal('prose');
+  });
+
+  it('is a block-level container query host', async () => {
+    const el = await fixture(html`<dvfy-page-section>x</dvfy-page-section>`);
+    const cs = getComputedStyle(el);
+    expect(cs.display).to.equal('block');
+  });
+});

--- a/components/dvfy-stack.js
+++ b/components/dvfy-stack.js
@@ -1,0 +1,79 @@
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-stack> — Flex wrapper with a token-scaled gap.
+ *
+ * Replaces invented `dvfy-flex dvfy-gap-* dvfy-justify-center` utility classes and
+ * implicit vertical spacing. The default is a vertical (column) stack — the most
+ * common landing-page rhythm need.
+ *
+ * Attributes:
+ *   direction: column | row    — main axis (default column)
+ *   gap:       sm | md | lg     — space between children (--dvfy-space-*; default md)
+ *   justify:   start | center | end | between — main-axis distribution (default start)
+ *   align:     start | center | end | stretch — cross-axis alignment (default stretch)
+ *
+ * Usage:
+ *   <dvfy-stack gap="md" align="center">
+ *     <dvfy-heading level="1">Title</dvfy-heading>
+ *     <dvfy-text size="lg" tone="muted">Subhead</dvfy-text>
+ *     <dvfy-button variant="primary">Go</dvfy-button>
+ *   </dvfy-stack>
+ */
+
+const STYLES = `
+dvfy-stack {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: column;
+  /* default gap = md */
+  gap: var(--dvfy-space-6);
+}
+
+/* Direction */
+dvfy-stack[direction="row"]    { flex-direction: row; flex-wrap: wrap; }
+dvfy-stack[direction="column"] { flex-direction: column; }
+
+/* Gap scale */
+dvfy-stack[gap="sm"] { gap: var(--dvfy-space-3); }
+dvfy-stack[gap="md"] { gap: var(--dvfy-space-6); }
+dvfy-stack[gap="lg"] { gap: var(--dvfy-space-10); }
+
+/* Justify (main axis) */
+dvfy-stack[justify="start"]   { justify-content: flex-start; }
+dvfy-stack[justify="center"]  { justify-content: center; }
+dvfy-stack[justify="end"]     { justify-content: flex-end; }
+dvfy-stack[justify="between"] { justify-content: space-between; }
+
+/* Align (cross axis) */
+dvfy-stack[align="start"]   { align-items: flex-start; }
+dvfy-stack[align="center"]  { align-items: center; }
+dvfy-stack[align="end"]     { align-items: flex-end; }
+dvfy-stack[align="stretch"] { align-items: stretch; }
+`;
+
+/**
+ * Flex wrapper with a token-scaled gap; vertical (column) by default.
+ *
+ * @element dvfy-stack
+ *
+ * @attr {string} direction - Main axis: column | row (default column)
+ * @attr {string} gap - Space between children: sm | md | lg (default md)
+ * @attr {string} justify - Main-axis distribution: start | center | end | between (default start)
+ * @attr {string} align - Cross-axis alignment: start | center | end | stretch (default stretch)
+ *
+ * @slot - Stack children
+ *
+ * @example
+ * <dvfy-stack gap="md" align="center">
+ *   <dvfy-heading level="1">Title</dvfy-heading>
+ *   <dvfy-text size="lg" tone="muted">Subhead</dvfy-text>
+ * </dvfy-stack>
+ */
+class DvfyStack extends HTMLElement {
+  connectedCallback() {
+    injectStyles('dvfy-stack', STYLES);
+  }
+}
+
+customElements.define('dvfy-stack', DvfyStack);

--- a/components/dvfy-stack.test.js
+++ b/components/dvfy-stack.test.js
@@ -1,0 +1,32 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-stack.js';
+
+describe('dvfy-stack', () => {
+  it('renders slotted children', async () => {
+    const el = await fixture(html`
+      <dvfy-stack><span>a</span><span>b</span></dvfy-stack>
+    `);
+    expect(el.children.length).to.equal(2);
+  });
+
+  it('uses display:flex, column by default', async () => {
+    const el = await fixture(html`<dvfy-stack><span>a</span></dvfy-stack>`);
+    const cs = getComputedStyle(el);
+    expect(cs.display).to.equal('flex');
+    expect(cs.flexDirection).to.equal('column');
+  });
+
+  it('switches to row direction', async () => {
+    const el = await fixture(html`<dvfy-stack direction="row"><span>a</span></dvfy-stack>`);
+    expect(getComputedStyle(el).flexDirection).to.equal('row');
+  });
+
+  it('applies justify and align', async () => {
+    const el = await fixture(html`
+      <dvfy-stack justify="center" align="center"><span>a</span></dvfy-stack>
+    `);
+    const cs = getComputedStyle(el);
+    expect(cs.justifyContent).to.equal('center');
+    expect(cs.alignItems).to.equal('center');
+  });
+});

--- a/components/dvfy-text.js
+++ b/components/dvfy-text.js
@@ -1,0 +1,113 @@
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-text> — Body text bound to the --dvfy-type-body-* + --dvfy-text-* tokens.
+ *
+ * Replaces invented `dvfy-body-lg / -md / -sm` and `dvfy-text-muted` utility classes.
+ * Renders a real <p> in the light DOM (block paragraph rhythm) unless `inline` is set.
+ * Size maps to the body role tokens; tone maps to the semantic text-color roles, so
+ * a theme restyles all copy globally.
+ *
+ * Attributes:
+ *   size:   lg | md | sm           — body size role (default md)
+ *   tone:   default | muted        — text color role (default default)
+ *   inline:                        — render as <span> instead of <p> (no block margin)
+ *
+ * Usage:
+ *   <dvfy-text size="lg">Puntuamos cada coche con un Chollo Score público.</dvfy-text>
+ *   <dvfy-text size="sm" tone="muted">Gratis · sin registro · sin compromiso</dvfy-text>
+ */
+
+const STYLES = `
+dvfy-text {
+  display: block;
+  color: var(--dvfy-text-primary);
+  /* default size = md (body) */
+  font-family: var(--dvfy-type-body-family);
+  font-size: var(--dvfy-type-body-size);
+  font-weight: var(--dvfy-type-body-weight);
+  line-height: var(--dvfy-type-body-leading);
+  letter-spacing: var(--dvfy-type-body-tracking);
+}
+
+dvfy-text[inline] { display: inline; }
+
+dvfy-text > p,
+dvfy-text > span {
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+}
+
+/* Size scale */
+dvfy-text[size="lg"] {
+  font-size: var(--dvfy-text-lg);
+  line-height: var(--dvfy-leading-relaxed);
+}
+dvfy-text[size="md"] {
+  font-family: var(--dvfy-type-body-family);
+  font-size: var(--dvfy-type-body-size);
+  font-weight: var(--dvfy-type-body-weight);
+  line-height: var(--dvfy-type-body-leading);
+}
+dvfy-text[size="sm"] {
+  font-family: var(--dvfy-type-body-sm-family);
+  font-size: var(--dvfy-type-body-sm-size);
+  font-weight: var(--dvfy-type-body-sm-weight);
+  line-height: var(--dvfy-type-body-sm-leading);
+}
+
+/* Tone (semantic text-color roles) */
+dvfy-text[tone="default"] { color: var(--dvfy-text-primary); }
+dvfy-text[tone="muted"]   { color: var(--dvfy-text-muted); }
+`;
+
+const VALID_SIZES = new Set(['lg', 'md', 'sm']);
+
+/**
+ * Body text bound to the --dvfy-type-body-* size roles and --dvfy-text-* color roles;
+ * renders a real <p> (or <span> when inline).
+ *
+ * @element dvfy-text
+ *
+ * @attr {string} size - Body size role: lg | md | sm (default md)
+ * @attr {string} tone - Text color role: default | muted (default default)
+ * @attr {boolean} inline - Render as <span> (inline) instead of <p> (block)
+ *
+ * @slot - Text content
+ *
+ * @cssprop {color} --dvfy-text-primary - Default tone color
+ * @cssprop {color} --dvfy-text-muted - Muted tone color
+ *
+ * @example
+ * <dvfy-text size="lg">Puntuamos cada coche con un Chollo Score público.</dvfy-text>
+ */
+class DvfyText extends HTMLElement {
+  connectedCallback() {
+    injectStyles('dvfy-text', STYLES);
+    this.#render();
+  }
+
+  static get observedAttributes() { return ['inline']; }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.#render();
+  }
+
+  #render() {
+    const tag = this.hasAttribute('inline') ? 'span' : 'p';
+
+    const existing = this.firstElementChild;
+    if (existing && existing.tagName.toLowerCase() === tag &&
+        this.childNodes.length === 1) {
+      return;
+    }
+
+    const wrap = document.createElement(tag);
+    while (this.firstChild) wrap.appendChild(this.firstChild);
+    this.appendChild(wrap);
+  }
+}
+
+customElements.define('dvfy-text', DvfyText);

--- a/components/dvfy-text.test.js
+++ b/components/dvfy-text.test.js
@@ -1,0 +1,27 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-text.js';
+
+describe('dvfy-text', () => {
+  it('renders a real <p> by default and keeps the text', async () => {
+    const el = await fixture(html`<dvfy-text>Chollo Score público</dvfy-text>`);
+    const p = el.firstElementChild;
+    expect(p.tagName.toLowerCase()).to.equal('p');
+    expect(p.textContent).to.equal('Chollo Score público');
+  });
+
+  it('renders a <span> when inline is set', async () => {
+    const el = await fixture(html`<dvfy-text inline>x</dvfy-text>`);
+    expect(el.firstElementChild.tagName.toLowerCase()).to.equal('span');
+  });
+
+  it('accepts size and tone attributes', async () => {
+    const el = await fixture(html`<dvfy-text size="sm" tone="muted">x</dvfy-text>`);
+    expect(el.getAttribute('size')).to.equal('sm');
+    expect(el.getAttribute('tone')).to.equal('muted');
+  });
+
+  it('produces exactly one wrapping element (no double-wrap)', async () => {
+    const el = await fixture(html`<dvfy-text>Once</dvfy-text>`);
+    expect(el.querySelectorAll('p,span').length).to.equal(1);
+  });
+});

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1385,6 +1385,41 @@
       ]
     },
     {
+      "name": "dvfy-grid",
+      "path": "./components/dvfy-grid.js",
+      "description": "Responsive equal-column grid that collapses to one column below the md breakpoint.",
+      "attributes": [
+        {
+          "name": "cols",
+          "description": "Equal columns at full width: 1 | 2 | 3 | 4 (default 1)",
+          "type": "string"
+        },
+        {
+          "name": "gap",
+          "description": "Gutter between cells: sm | md | lg (default md)",
+          "type": "string"
+        },
+        {
+          "name": "min",
+          "description": "Auto-fit track minimum length (e.g. \"16rem\"); overrides cols when set",
+          "type": "string"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Grid cells"
+        }
+      ],
+      "cssProperties": [
+        {
+          "name": "--dvfy-grid-min",
+          "description": "Minimum track size for auto-fit mode (default 16rem)",
+          "type": "length"
+        }
+      ]
+    },
+    {
       "name": "dvfy-hamburger",
       "path": "./components/dvfy-hamburger.js",
       "description": "State-driven animated icon button — a Tier 1 primitive for menu toggles\nand other binary/multi-state controls.\n\nFive visual states (hamburger, x, chevron-left, chevron-right, minus) are\ndriven by the `state` attribute. CSS transitions interpolate between any\ntwo states automatically; consumers set the state, the component animates.\n\nComposable into nav, header, drawer, sidebar, stepper, and modal components.",
@@ -1468,6 +1503,41 @@
           "name": "--dvfy-hamburger-bg",
           "description": "Button background (default: transparent)",
           "type": "color"
+        }
+      ]
+    },
+    {
+      "name": "dvfy-heading",
+      "path": "./components/dvfy-heading.js",
+      "description": "Semantic heading bound to the --dvfy-type-h{level}-* role tokens; renders a real\n<h1>/<h2>/<h3> so the document keeps a correct heading outline.",
+      "attributes": [
+        {
+          "name": "level",
+          "description": "Heading level / role token: 1 | 2 | 3 (default 2)",
+          "type": "string"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Heading text"
+        }
+      ],
+      "cssProperties": [
+        {
+          "name": "--dvfy-type-h1-size",
+          "description": "H1 font size (and family/weight/leading/tracking siblings)",
+          "type": "*"
+        },
+        {
+          "name": "--dvfy-type-h2-size",
+          "description": "H2 font size (and siblings)",
+          "type": "*"
+        },
+        {
+          "name": "--dvfy-type-h3-size",
+          "description": "H3 font size (and siblings)",
+          "type": "*"
         }
       ]
     },
@@ -2018,6 +2088,56 @@
         {
           "name": "--dvfy-nav-link-active",
           "description": "Active link color (default: var(--dvfy-primary-bg))",
+          "type": "color"
+        }
+      ]
+    },
+    {
+      "name": "dvfy-page-section",
+      "path": "./components/dvfy-page-section.js",
+      "description": "Page vertical-rhythm wrapper for landing-page sections.",
+      "attributes": [
+        {
+          "name": "padding",
+          "description": "Vertical rhythm scale: md | lg | xl (default lg)",
+          "type": "string"
+        },
+        {
+          "name": "align",
+          "description": "Content alignment: left | center (default left)",
+          "type": "string"
+        },
+        {
+          "name": "tone",
+          "description": "Background tone: default | muted | brand (default default)",
+          "type": "string"
+        },
+        {
+          "name": "width",
+          "description": "Inner content rail: prose | wide | full (default wide)",
+          "type": "string"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Section content"
+        }
+      ],
+      "cssProperties": [
+        {
+          "name": "--dvfy-surface-page",
+          "description": "Default tone background",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-surface-muted",
+          "description": "Muted tone background",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-primary-bg-subtle",
+          "description": "Brand tone background",
           "type": "color"
         }
       ]
@@ -3049,6 +3169,39 @@
       ]
     },
     {
+      "name": "dvfy-stack",
+      "path": "./components/dvfy-stack.js",
+      "description": "Flex wrapper with a token-scaled gap; vertical (column) by default.",
+      "attributes": [
+        {
+          "name": "direction",
+          "description": "Main axis: column | row (default column)",
+          "type": "string"
+        },
+        {
+          "name": "gap",
+          "description": "Space between children: sm | md | lg (default md)",
+          "type": "string"
+        },
+        {
+          "name": "justify",
+          "description": "Main-axis distribution: start | center | end | between (default start)",
+          "type": "string"
+        },
+        {
+          "name": "align",
+          "description": "Cross-axis alignment: start | center | end | stretch (default stretch)",
+          "type": "string"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Stack children"
+        }
+      ]
+    },
+    {
       "name": "dvfy-stagger-enter",
       "path": "./components/dvfy-stagger-enter.js",
       "description": "Staggered DOM-enter animation container. Children animate in on mount\nusing",
@@ -3506,6 +3659,46 @@
         {
           "name": "--dvfy-vortex-color",
           "description": "Override text color",
+          "type": "color"
+        }
+      ]
+    },
+    {
+      "name": "dvfy-text",
+      "path": "./components/dvfy-text.js",
+      "description": "Body text bound to the --dvfy-type-body-* size roles and --dvfy-text-* color roles;\nrenders a real <p> (or <span> when inline).",
+      "attributes": [
+        {
+          "name": "size",
+          "description": "Body size role: lg | md | sm (default md)",
+          "type": "string"
+        },
+        {
+          "name": "tone",
+          "description": "Text color role: default | muted (default default)",
+          "type": "string"
+        },
+        {
+          "name": "inline",
+          "description": "Render as <span> (inline) instead of <p> (block)",
+          "type": "boolean"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Text content"
+        }
+      ],
+      "cssProperties": [
+        {
+          "name": "--dvfy-text-primary",
+          "description": "Default tone color",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-text-muted",
+          "description": "Muted tone color",
           "type": "color"
         }
       ]

--- a/devify.js
+++ b/devify.js
@@ -72,6 +72,13 @@ import './components/dvfy-description-list.js';
 import './components/dvfy-command-palette.js';
 import './components/dvfy-stepper.js';
 
+// Wave 5: Page Composition (layout + typography primitives)
+import './components/dvfy-page-section.js';
+import './components/dvfy-grid.js';
+import './components/dvfy-stack.js';
+import './components/dvfy-heading.js';
+import './components/dvfy-text.js';
+
 // Wave 4: Billing & Payments
 import './components/dvfy-usage-meter.js';
 import './components/dvfy-invoice-list.js';

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@
 | [`react/`](react/index.html) | React 18 | CDN demo + `App.jsx` production patterns |
 | [`vue/`](vue/index.html) | Vue 3 | CDN demo + `App.vue` SFC with Vite setup |
 | [`svelte/`](svelte/index.html) | Svelte 5 | CDN demo + `App.svelte` SvelteKit setup |
+| [`composition/`](composition/index.html) | Vanilla HTML | §8 landing page composed only from the page-composition primitives (`dvfy-page-section` / `dvfy-grid` / `dvfy-stack` / `dvfy-heading` / `dvfy-text`) — zero invented utility classes. Verified by `npm run verify:composition`. |
 
 ## Installation
 

--- a/examples/composition/index.html
+++ b/examples/composition/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<!--
+  Page-composition primitives demo (devify-ui#372 / LP-Factory N1 / G2 proof).
+
+  This page is the acceptance proof: a §8-shaped landing page composed ONLY from the
+  sanctioned composition vocabulary — dvfy-page-section / dvfy-grid / dvfy-stack /
+  dvfy-heading / dvfy-text — plus existing library components (dvfy-section-hero,
+  dvfy-card-glow, dvfy-button). It uses ZERO invented utility classes: no dvfy-py-*,
+  no dvfy-grid-cols-*, no dvfy-heading-1, no dvfy-text-muted. Every layout/typography
+  decision flows through a manifest-declared element bound to existing tokens.
+
+  Themed via data-theme="renting-ideal" on <html> per the integration KB
+  (a complete semantic theme on the document root — not an unthemed page).
+-->
+<html lang="es" data-theme="renting-ideal">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Renting Ideal — composición §8 (demo de primitivas)</title>
+  <meta name="description" content="Demostración de las primitivas de composición de @devify/ui sobre el esqueleto §8 de la landing.">
+  <link rel="stylesheet" href="../../devify.css">
+  <link rel="stylesheet" href="../../tokens/themes/renting-ideal.css">
+  <script type="module" src="../../devify.js"></script>
+  <style>
+    /* Page reset only — no layout/typography utilities, those are primitives. */
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--dvfy-surface-page); color: var(--dvfy-text-primary); }
+  </style>
+</head>
+<body>
+  <!-- §8 slot 1 — HERO (existing dvfy-section-hero + typography primitives) -->
+  <dvfy-section-hero tone="brand" padding="xl" align="center">
+    <dvfy-heading level="1">Tu mejor renting, sin que ninguna marca te lo venda</dvfy-heading>
+    <dvfy-text size="lg">
+      Puntuamos cada coche con un Chollo Score público 0–10, fórmula determinista y auditable.
+      Gratis, sin compromiso y sin pedirte tus ingresos.
+    </dvfy-text>
+    <dvfy-button variant="primary" size="lg">Empezar — 6 preguntas, &lt; 2 min</dvfy-button>
+    <div slot="trust">
+      <dvfy-text size="sm" tone="muted" inline>Imparcial · Transparente · Gratis · Sin registro</dvfy-text>
+    </div>
+  </dvfy-section-hero>
+
+  <!-- §8 slot 2 — HOW IT WORKS (page-section + grid + cards + typography) -->
+  <dvfy-page-section tone="default" padding="xl" align="center" width="wide">
+    <dvfy-stack gap="lg" align="center">
+      <dvfy-heading level="2">Cómo funciona</dvfy-heading>
+      <dvfy-grid cols="3" gap="lg">
+        <dvfy-card-glow padded>
+          <dvfy-heading level="3">1 · Cuéntanos</dvfy-heading>
+          <dvfy-text>Responde 6 preguntas sobre lo que necesitas. Sin registro.</dvfy-text>
+        </dvfy-card-glow>
+        <dvfy-card-glow padded>
+          <dvfy-heading level="3">2 · Puntuamos</dvfy-heading>
+          <dvfy-text>Calculamos el Chollo Score público de cada coche con la misma fórmula.</dvfy-text>
+        </dvfy-card-glow>
+        <dvfy-card-glow padded>
+          <dvfy-heading level="3">3 · Decides</dvfy-heading>
+          <dvfy-text>Te mostramos tu mejor opción. Sin pujas de marca, sin sorpresas.</dvfy-text>
+        </dvfy-card-glow>
+      </dvfy-grid>
+    </dvfy-stack>
+  </dvfy-page-section>
+
+  <!-- §8 slot 3 — TRUST / SOCIAL-PROOF substitute (page-section + typography) -->
+  <dvfy-page-section tone="muted" padding="lg" align="center" width="prose">
+    <dvfy-stack gap="md" align="center">
+      <dvfy-heading level="2">Transparencia como prueba</dvfy-heading>
+      <dvfy-text size="lg">
+        El Chollo Score es público y auditable componente a componente: precio,
+        preferencias, km, fiscalidad y plazo. Misma situación, misma puntuación.
+      </dvfy-text>
+      <dvfy-button variant="secondary">Ver cómo se calcula</dvfy-button>
+    </dvfy-stack>
+  </dvfy-page-section>
+
+  <!-- §8 slot 4 — OBJECTION / FAQ (page-section + 2-col grid + cards + typography) -->
+  <dvfy-page-section tone="default" padding="xl" align="left" width="wide">
+    <dvfy-stack gap="lg">
+      <dvfy-heading level="2">¿Dónde está el truco?</dvfy-heading>
+      <dvfy-grid cols="2" gap="md">
+        <dvfy-card-glow padded>
+          <dvfy-heading level="3">¿Sois imparciales?</dvfy-heading>
+          <dvfy-text>Sí. Ninguna marca puja por aparecer. La fórmula es la misma para todos.</dvfy-text>
+        </dvfy-card-glow>
+        <dvfy-card-glow padded>
+          <dvfy-heading level="3">¿Es gratis de verdad?</dvfy-heading>
+          <dvfy-text>Gratis, sin registro y sin compromiso. La comisión la paga el proveedor, nunca tú.</dvfy-text>
+        </dvfy-card-glow>
+      </dvfy-grid>
+    </dvfy-stack>
+  </dvfy-page-section>
+
+  <!-- §8 slot 5 — RISK-REVERSAL + repeat CTA (page-section + stack + typography) -->
+  <dvfy-page-section tone="brand" padding="xl" align="center" width="prose">
+    <dvfy-stack gap="md" align="center">
+      <dvfy-heading level="2">Encuentra tu renting ideal</dvfy-heading>
+      <dvfy-text size="lg" tone="muted">Gratis · sin compromiso · sin registro</dvfy-text>
+      <dvfy-button variant="primary" size="lg">Empezar ahora</dvfy-button>
+    </dvfy-stack>
+  </dvfy-page-section>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@web/test-runner-playwright": "^0.11.1",
     "esbuild": "^0.27.4",
     "eslint": "^10.1.0",
+    "playwright": "^1.58.2",
     "stylelint": "^17.6.0",
     "stylelint-config-standard": "^40.0.0",
     "web-component-analyzer": "^2.0.0"
@@ -66,6 +67,7 @@
     "lint:css": "stylelint 'tokens/**/*.css'",
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch",
+    "verify:composition": "node scripts/verify-composition-demo.mjs",
     "build": "node scripts/build.js"
   }
 }

--- a/scripts/verify-composition-demo.mjs
+++ b/scripts/verify-composition-demo.mjs
@@ -1,0 +1,154 @@
+/**
+ * verify-composition-demo.mjs — real-browser e2e proof for devify-ui#372 (LP-Factory N1 / G2).
+ *
+ * Drives the served composition demo in headless Chromium and asserts the WHOLE POINT
+ * of the issue: the §8 page composed only from the sanctioned primitives renders with
+ * ZERO unresolved/dead classes, every primitive upgrades, applies real token-bound
+ * computed styles, and the page is actually themed (not unthemed).
+ *
+ * Reuses the cached Playwright chromium. Spins up a static server on a free port.
+ *
+ * Usage: node scripts/verify-composition-demo.mjs
+ * Exit 0 = proof holds; exit 1 = a dead class / unstyled primitive / unthemed page.
+ */
+// eslint-disable-next-line import-x/no-extraneous-dependencies -- dev/CI verify tool; not part of the shipped package (scripts/ is excluded from `files`)
+import { chromium } from 'playwright';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.json': 'application/json' };
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let rel = decodeURIComponent(req.url.split('?')[0]);
+    if (rel.endsWith('/')) rel += 'index.html';
+    const file = path.join(ROOT, rel);
+    if (!file.startsWith(ROOT)) { res.writeHead(403).end(); return; }
+    const body = await readFile(file);
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end('not found');
+  }
+});
+
+const fail = (msg) => { console.error('FAIL:', msg); process.exitCode = 1; };
+const ok = msg => console.log('  ok —', msg);
+
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+const url = `http://127.0.0.1:${port}/examples/composition/`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+
+const consoleErrors = [];
+page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+page.on('pageerror', e => consoleErrors.push(String(e)));
+
+await page.goto(url, { waitUntil: 'networkidle' });
+await page.waitForFunction(() => customElements.get('dvfy-page-section') !== undefined);
+
+console.log(`Composition demo e2e — ${url}\n`);
+
+// 1. Every primitive family upgraded (custom element defined + present on the page).
+const families = ['dvfy-page-section', 'dvfy-grid', 'dvfy-stack', 'dvfy-heading', 'dvfy-text'];
+const upgrade = await page.evaluate(fams => fams.map(f => ({
+  f, defined: !!customElements.get(f), count: document.querySelectorAll(f).length,
+})), families);
+for (const u of upgrade) {
+  if (!u.defined) fail(`${u.f} is not a defined custom element (did not register)`);
+  else if (u.count === 0) fail(`${u.f} not present on the demo page`);
+  else ok(`${u.f} upgraded — ${u.count} instance(s)`);
+}
+
+// 2. ZERO dead/invented utility classes. The G2 failure mode is stringly-typed classes
+//    that resolve to nothing. Assert the page carries NO class attribute at all on any
+//    element except the documented page-reset selectors (there are none here) — the
+//    composition is 100% elements + attributes, not classes.
+const strayClasses = await page.evaluate(() => {
+  const bad = [];
+  for (const el of document.querySelectorAll('body *')) {
+    for (const c of el.classList) {
+      // any dvfy-* utility-looking class on a consumer element is the dead-class smell
+      if (c.startsWith('dvfy-')) bad.push(`${el.tagName.toLowerCase()}.${c}`);
+    }
+  }
+  return bad;
+});
+if (strayClasses.length) fail(`invented/dead dvfy-* utility classes found: ${strayClasses.join(', ')}`);
+else ok('zero invented dvfy-* utility classes in the composed page (closed vocabulary holds)');
+
+// 3. Primitives applied REAL token-bound computed styles (not unstyled fallback).
+const styled = await page.evaluate(() => {
+  const grid = document.querySelector('dvfy-grid[cols="3"]');
+  const stack = document.querySelector('dvfy-stack');
+  const section = document.querySelector('dvfy-page-section[tone="muted"]');
+  const cs = el => el ? getComputedStyle(el) : null;
+  const gs = cs(grid), ss = cs(stack), secs = cs(section);
+  return {
+    gridDisplay: gs && gs.display,
+    gridCols: gs && gs.gridTemplateColumns,           // 3 tracks at >= md width
+    gridGap: gs && gs.gap,                             // resolved from --dvfy-space-*
+    stackDisplay: ss && ss.display,
+    stackDir: ss && ss.flexDirection,
+    sectionBg: secs && secs.backgroundColor,          // muted surface token, not transparent
+    sectionPadTop: secs && secs.paddingTop,           // clamped padding, not 0
+  };
+});
+if (styled.gridDisplay !== 'grid') fail(`dvfy-grid did not apply display:grid (got ${styled.gridDisplay})`);
+else ok(`dvfy-grid display:grid, gap=${styled.gridGap}, tracks="${styled.gridCols}"`);
+if (!/(\d.*){2,}/.test(styled.gridCols) || styled.gridCols.split(' ').length < 3) {
+  fail(`dvfy-grid cols=3 did not resolve to 3 tracks at desktop width (got "${styled.gridCols}")`);
+} else ok('dvfy-grid cols=3 resolved to 3 tracks at desktop width');
+if (styled.stackDisplay !== 'flex' || styled.stackDir !== 'column') fail(`dvfy-stack flex/column not applied (${styled.stackDisplay}/${styled.stackDir})`);
+else ok('dvfy-stack display:flex direction:column applied');
+if (!styled.sectionBg || styled.sectionBg === 'rgba(0, 0, 0, 0)' || styled.sectionBg === 'transparent') {
+  fail(`dvfy-page-section[tone=muted] background did not resolve to a token (got ${styled.sectionBg})`);
+} else ok(`dvfy-page-section tone=muted background resolved (${styled.sectionBg}), padding-top=${styled.sectionPadTop}`);
+
+// 4. Typography primitives produced REAL semantic tags + token-bound sizes.
+const typo = await page.evaluate(() => {
+  const h1 = document.querySelector('dvfy-heading[level="1"] > h1');
+  const h2 = document.querySelector('dvfy-heading[level="2"] > h2');
+  const p = document.querySelector('dvfy-text:not([inline]) > p');
+  const h1count = document.querySelectorAll('h1').length;
+  return {
+    hasH1: !!h1, hasH2: !!h2, hasP: !!p, h1count,
+    h1Size: h1 ? getComputedStyle(h1).fontSize : null,
+    pSize: p ? getComputedStyle(p).fontSize : null,
+  };
+});
+if (!typo.hasH1) fail('dvfy-heading level=1 did not render a real <h1>');
+else ok(`dvfy-heading level=1 → real <h1> (font-size ${typo.h1Size})`);
+if (!typo.hasH2) fail('dvfy-heading level=2 did not render a real <h2>');
+else ok('dvfy-heading level=2 → real <h2>');
+if (!typo.hasP) fail('dvfy-text did not render a real <p>');
+else ok(`dvfy-text → real <p> (font-size ${typo.pSize})`);
+if (typo.h1count !== 1) fail(`SEO single-<h1> expected; found ${typo.h1count}`);
+else ok('exactly one <h1> on the page (SEO baseline)');
+
+// 5. Page is actually THEMED (renting-ideal applied on <html>, not unthemed).
+const theme = await page.evaluate(() => ({
+  dataTheme: document.documentElement.getAttribute('data-theme'),
+  bodyBg: getComputedStyle(document.body).backgroundColor,
+  textPrimary: getComputedStyle(document.body).color,
+}));
+if (theme.dataTheme !== 'renting-ideal') fail(`page not themed via data-theme (got ${theme.dataTheme})`);
+else ok(`page themed: data-theme=${theme.dataTheme}, body bg=${theme.bodyBg}, text=${theme.textPrimary}`);
+
+// 6. No console/page errors (a missing element or bad import would surface here).
+if (consoleErrors.length) fail(`console/page errors: ${consoleErrors.join(' | ')}`);
+else ok('no console or page errors');
+
+await browser.close();
+server.close();
+
+if (process.exitCode === 1) {
+  console.error('\nComposition demo proof FAILED.');
+} else {
+  console.log('\nComposition demo proof PASSED — §8 page renders with zero dead classes, fully themed.');
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,22 +6,30 @@ Follow studio/ standards: G&P, Verification Before Completion, citations to `stu
 
 **Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
 
-## Current Focus — devify-ui#369: AA-correct theme-generator (PR #368)
+## Current Focus — devify-ui#372: Page-composition primitives (LP-Factory N1 / G2)
 
-G&P: Make `tokens/theme-generator.js` derive on-status + dark primary text by
-measured WCAG-AA contrast (not a fixed near-black/near-white assumption), so every
-seed produces an AA-passing theme. Preserve brand hues — only adjust the on-color/text.
+G&P: Replace rueda's ~24 invented utility classes with 4 sanctioned, manifest-declared
+light-DOM primitive families bound to EXISTING tokens — the composition vocabulary the
+LP factory's `ui:verify` gate (#305) validates against. Spec: studio
+`roadmaps/lp-factory-poc/session-2-seam-set.md` §2. Branch: `feat/372-composition-primitives`.
 
-- [ ] Add a contrast-aware on-color selector helper to theme-generator.js (pick black/white/nearest passing tier by measured ratio vs the actual bg)
-- [ ] Apply to --dvfy-on-success / -warning / -info / -danger (light + dark)
-- [ ] Apply to --dvfy-primary-text vs --dvfy-primary-bg (light + dark — dark CTA is highest-stakes)
-- [ ] Regenerate renting-ideal.css via npm run themes:gen
-- [ ] Regenerate cyan/pink/light/dark via their generators (drift-check green)
-- [ ] Register renting-ideal in check-contrast.js + remove the temporary exclusion NOTE
-- [ ] contrast:ci green for ALL themes (incl renting-ideal + -dark)
-- [ ] lint + themes:check green
-- [ ] Real-browser Playwright: status badges + dark CTA legible; brand hues unchanged before/after
-- [ ] Commit (author Jorge, no AI attribution), push, update PR #368 (+Closes #369)
+Build (4 families, light-DOM injectStyles pattern, tokens only):
+- [ ] `dvfy-page-section` — padding=md|lg|xl (fluid clamp), align=left|center, tone=default|muted|brand, width=prose|wide|full
+- [ ] `dvfy-grid` — cols=1|2|3|4, min (auto-fit), gap=sm|md|lg; collapse to 1col below md via @container
+- [ ] `dvfy-stack` — direction=column|row, gap=sm|md|lg, justify, align
+- [ ] `dvfy-heading` (level=1|2|3) + `dvfy-text` (size=lg|md|sm, tone=muted|default) bound to type/text tokens
+- [ ] Register in devify.js + per-family .test.js
+
+Verify (Verification Before Completion):
+- [ ] `npm run analyze` → 4 families + attrs in custom-elements.json
+- [ ] Demo page composed ONLY from primitives → zero dead/unresolved classes (real-browser e2e)
+- [ ] `npm run lint` + `npm run test` + `npm run contrast:ci` green
+
+Scope guard: ONLY the 4 families + manifest + demo. NOT #363 (button href), NOT #367 (contract artifact).
+
+Token decision (design-thinking — all EXISTING, no new scales): space-* (clamps/gaps),
+type-h1/2/3-* + type-body-* + text-* (typography), surface-page/muted + primary-bg-subtle +
+text-primary/secondary/muted (tone), container-* + prose-* (width), 48rem @container collapse.
 
 ## Backlog
 


### PR DESCRIPTION
Closes #372. LP-Factory POC Session 3 build (N1 / G2 producer). Source: studio `roadmaps/lp-factory-poc/session-2-seam-set.md` §2.

## Why
Rueda's LP is built on ~24 invented utility classes (`dvfy-py-2xl`, `dvfy-grid-cols-3`, `dvfy-heading-1`, `dvfy-text-muted`, …) that resolve to **nothing** — the G2 failure the LP factory exists to fix. This PR replaces them with a sanctioned, manifest-declared composition vocabulary bound to existing tokens.

## The 4 primitive families (attributes per seam-set §2)
- **`dvfy-page-section`** — page rhythm wrapper. `padding=md|lg|xl` (fluid clamp on `--dvfy-space-*`), `align=left|center`, `tone=default|muted|brand`, `width=prose|wide|full`. NOT `dvfy-section` (the collapsible disclosure widget — name collision avoided per §0).
- **`dvfy-grid`** — responsive grid. `cols=1|2|3|4`, `min` (auto-fit tracks), `gap=sm|md|lg`; collapses to one column below the md breakpoint via a **container query**.
- **`dvfy-stack`** — flex wrapper. `direction=column|row`, `gap=sm|md|lg`, `justify`, `align`.
- **`dvfy-heading`** (`level=1|2|3`) + **`dvfy-text`** (`size=lg|md|sm`, `tone=default|muted`, `inline`) — typography bound to `--dvfy-type-h{1,2,3}-*` / `--dvfy-type-body-*` / `--dvfy-text-*`. `dvfy-heading` renders a real `<h1>/<h2>/<h3>` so the document keeps a correct heading outline (SEO single-`<h1>`).

All bind to **existing** space/type/surface tokens — no new token scales (design-thinking: tokens read first; no gaps surfaced). Light-DOM `injectStyles` pattern, matching `dvfy-section-hero` / `dvfy-card-glow`.

## Verification (Verification Before Completion / Iron Law)
- `npm run analyze` → all 5 elements + their exact §2 attributes in `custom-elements.json`.
- **`npm run verify:composition`** — a real **headless-Chromium e2e** drives `examples/composition/`, a §8-shaped landing page composed ONLY from these primitives (themed `data-theme="renting-ideal"` on `<html>`). It asserts: every primitive upgrades, applies real token-bound computed styles (grid→3 tracks, stack→flex/column, page-section→themed muted surface), **zero invented `dvfy-*` utility classes**, typography → real semantic tags with exactly one `<h1>`, page is actually themed, no console errors. **PASSED.**
- `npm run lint` (eslint + stylelint + check:tokens + check:dvfy-pref) — green.
- `npm run test` — **1450 passed, 0 failed** (incl. 22 new tests across the 5 families).
- `npm run contrast:ci` — **120 pairs pass, 0 fail** (WCAG AA).

## Scope
Only the 4 families + manifest + demo proof. **Fast-follows (separate approved issues, not in this PR):** #363 (native `<dvfy-button href>`), #367 (composition-vocabulary Contract artifact + `npm run contract` — these families are its first declarations).