### PR TITLE
feat(dvfy-button): native href navigation (link semantics)

### DIFF
--- a/components/dvfy-button.js
+++ b/components/dvfy-button.js
@@ -1,4 +1,5 @@
 import { injectStyles } from '../utils/styles.js';
+import { sanitizeHref } from '../utils/url.js';
 
 /* <dvfy-button> — Button component */
 
@@ -161,6 +162,9 @@ dvfy-button[loading]::after {
  * @attr {boolean} disabled - Disable button and prevent interaction
  * @attr {boolean} loading - Show loading state with spinner indicator
  * @attr {string} type - HTML button type: button | submit | reset (default: "button")
+ * @attr {string} href - When set, the button behaves as a link (role="link") and navigates on click/Enter
+ * @attr {string} target - Link target for href navigation (e.g. "_blank"); only applies when href is set
+ * @attr {string} rel - Link relationship for href navigation; defaults to "noopener noreferrer" when target="_blank"
  * @attr {string} from - Gradient start color for variant="gradient" (default: "#7c3aed")
  * @attr {string} to - Gradient end color for variant="gradient" (default: "#2563eb")
  *
@@ -177,7 +181,7 @@ class DvfyButton extends HTMLElement {
     if (this.hasAttribute('from')) this.style.setProperty('--dvfy-btn-grad-from', this.getAttribute('from'));
     if (this.hasAttribute('to')) this.style.setProperty('--dvfy-btn-grad-to', this.getAttribute('to'));
 
-    if (!this.getAttribute('role')) this.setAttribute('role', 'button');
+    this.#syncRole();
     if (!this.getAttribute('tabindex') && !this.hasAttribute('disabled')) {
       this.setAttribute('tabindex', '0');
     }
@@ -193,13 +197,23 @@ class DvfyButton extends HTMLElement {
   }
 
   #onKey = (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+    // Links activate on Enter only (native anchor semantics); buttons also on Space.
+    const isLink = this.hasAttribute('href');
+    if (e.key === 'Enter' || (!isLink && e.key === ' ')) {
       e.preventDefault();
       this.click();
     }
   };
 
-  #onClick = () => {
+  #onClick = (e) => {
+    if (this.hasAttribute('disabled') || this.hasAttribute('loading')) return;
+
+    // Link behavior takes precedence: navigate when href is present.
+    if (this.hasAttribute('href')) {
+      this.#navigateFromHref(e);
+      return;
+    }
+
     const type = this.getAttribute('type');
     if (!type || type === 'button') return;
     const form = this.closest('form');
@@ -208,7 +222,25 @@ class DvfyButton extends HTMLElement {
     else if (type === 'reset') form.reset();
   };
 
-  static get observedAttributes() { return ['disabled', 'loading', 'from', 'to']; }
+  #navigateFromHref(e) {
+    const url = sanitizeHref(this.getAttribute('href'));
+    const target = this.getAttribute('target');
+    if (target === '_blank') {
+      // Safe defaults: opener-isolated + no referrer unless the author overrides rel.
+      const features = this.getAttribute('rel') || 'noopener noreferrer';
+      this._openTab(url, features);
+    } else {
+      this._navigate(url);
+    }
+    // A synthetic .click() has no default to prevent; guard for real events.
+    e?.preventDefault?.();
+  }
+
+  // Overridable seams (kept on the instance so tests can stub navigation).
+  _navigate(url) { window.location.assign(url); }
+  _openTab(url, features) { window.open(url, '_blank', features); }
+
+  static get observedAttributes() { return ['disabled', 'loading', 'from', 'to', 'href']; }
 
   attributeChangedCallback(name, _old, value) {
     if (name === 'disabled') {
@@ -219,11 +251,23 @@ class DvfyButton extends HTMLElement {
     if (name === 'loading') {
       this.setAttribute('aria-busy', String(this.hasAttribute('loading')));
     }
+    if (name === 'href') {
+      this.#syncRole();
+    }
     if (name === 'from') {
       this.style.setProperty('--dvfy-btn-grad-from', value ?? '');
     }
     if (name === 'to') {
       this.style.setProperty('--dvfy-btn-grad-to', value ?? '');
+    }
+  }
+
+  #syncRole() {
+    const role = this.hasAttribute('href') ? 'link' : 'button';
+    // Respect an author-supplied role only if it isn't the one we manage.
+    const current = this.getAttribute('role');
+    if (current === 'link' || current === 'button' || current === null) {
+      this.setAttribute('role', role);
     }
   }
 

--- a/components/dvfy-button.test.js
+++ b/components/dvfy-button.test.js
@@ -73,6 +73,90 @@ describe('dvfy-button', () => {
     });
   });
 
+  describe('href navigation', () => {
+    it('sets role=link (not button) when href is present', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      expect(el.getAttribute('role')).to.equal('link');
+      expect(el.getAttribute('tabindex')).to.equal('0');
+      await checkA11y(el);
+    });
+
+    it('navigates same-tab on click when href is set', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      let navigated = null;
+      el._navigate = (url) => { navigated = url; };
+      el.click();
+      expect(navigated).to.equal('/cuestionario');
+    });
+
+    it('navigates on Enter key when href is set', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      let navigated = null;
+      el._navigate = (url) => { navigated = url; };
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      expect(navigated).to.equal('/cuestionario');
+    });
+
+    it('sanitizes a javascript: href to # (no navigation to script)', async () => {
+      const el = await fixture(html`<dvfy-button href="javascript:alert(1)">Bad</dvfy-button>`);
+      let navigated = null;
+      el._navigate = (url) => { navigated = url; };
+      el.click();
+      expect(navigated).to.equal('#');
+    });
+
+    it('opens a new tab for target=_blank', async () => {
+      const el = await fixture(html`<dvfy-button href="https://example.com" target="_blank">Ext</dvfy-button>`);
+      let opened = null;
+      el._openTab = (url, features) => { opened = { url, features }; };
+      el.click();
+      expect(opened.url).to.equal('https://example.com');
+      expect(opened.features).to.contain('noopener');
+      expect(opened.features).to.contain('noreferrer');
+    });
+
+    it('honors an explicit rel attribute for target=_blank', async () => {
+      const el = await fixture(html`<dvfy-button href="https://example.com" target="_blank" rel="noopener">Ext</dvfy-button>`);
+      let opened = null;
+      el._openTab = (url, features) => { opened = { url, features }; };
+      el.click();
+      expect(opened.features).to.contain('noopener');
+      expect(opened.features).to.not.contain('noreferrer');
+    });
+
+    it('does not navigate when disabled', async () => {
+      const el = await fixture(html`<dvfy-button href="/x" disabled>Go</dvfy-button>`);
+      let navigated = false;
+      el._navigate = () => { navigated = true; };
+      el.click();
+      expect(navigated).to.equal(false);
+    });
+
+    it('does not navigate when loading', async () => {
+      const el = await fixture(html`<dvfy-button href="/x" loading>Go</dvfy-button>`);
+      let navigated = false;
+      el._navigate = () => { navigated = true; };
+      el.click();
+      expect(navigated).to.equal(false);
+    });
+
+    it('keeps role=button and does not navigate when href is absent (regression)', async () => {
+      const el = await fixture(html`<dvfy-button>Plain</dvfy-button>`);
+      expect(el.getAttribute('role')).to.equal('button');
+      let navigated = false;
+      el._navigate = () => { navigated = true; };
+      el.click();
+      expect(navigated).to.equal(false);
+    });
+
+    it('switches role from button to link when href is added dynamically', async () => {
+      const el = await fixture(html`<dvfy-button>Plain</dvfy-button>`);
+      expect(el.getAttribute('role')).to.equal('button');
+      el.setAttribute('href', '/later');
+      expect(el.getAttribute('role')).to.equal('link');
+    });
+  });
+
   describe('gradient attributes', () => {
     it('sets CSS custom properties from from/to attributes', async () => {
       const el = await fixture(html`<dvfy-button variant="gradient" from="#ff0000" to="#00ff00">Gradient</dvfy-button>`);

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -345,6 +345,16 @@
           "type": "string"
         },
         {
+          "name": "target",
+          "description": "Link target for href navigation (e.g. \"_blank\"); only applies when href is set",
+          "type": "string"
+        },
+        {
+          "name": "rel",
+          "description": "Link relationship for href navigation; defaults to \"noopener noreferrer\" when target=\"_blank\"",
+          "type": "string"
+        },
+        {
           "name": "disabled",
           "description": "Disable button and prevent interaction",
           "type": "boolean"
@@ -362,6 +372,11 @@
         {
           "name": "to",
           "description": "Gradient end color for variant=\"gradient\" (default: \"#2563eb\")",
+          "type": "string"
+        },
+        {
+          "name": "href",
+          "description": "When set, the button behaves as a link (role=\"link\") and navigates on click/Enter",
           "type": "string"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch",
     "verify:composition": "node scripts/verify-composition-demo.mjs",
+    "verify:button-href": "node scripts/verify-button-href.mjs",
     "build": "node scripts/build.js"
   }
 }

--- a/scripts/verify-button-href.mjs
+++ b/scripts/verify-button-href.mjs
@@ -1,0 +1,104 @@
+/**
+ * verify-button-href.mjs — real-browser e2e proof for devify-ui#363.
+ *
+ * Drives the actual shipped <dvfy-button.js> in headless Chromium and asserts the WHOLE
+ * POINT of the issue: a primary CTA with `href` is a REAL link — clicking it actually
+ * changes window.location (no stub), Enter navigates too, role=link is set, and a plain
+ * (no-href) button still does NOT navigate. Unit tests stub navigation; this proves the
+ * browser really moves. Catches the exact rueda "dead hero CTA" regression.
+ *
+ * Reuses the cached Playwright chromium. Spins up a static server on a free port that
+ * serves the repo (so the real component module loads) plus two synthetic routes.
+ *
+ * Usage: node scripts/verify-button-href.mjs
+ * Exit 0 = navigation proven; exit 1 = dead CTA / wrong semantics.
+ */
+// eslint-disable-next-line import-x/no-extraneous-dependencies -- dev/CI verify tool; not shipped (scripts/ excluded from `files`)
+import { chromium } from 'playwright';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json' };
+
+const HOME = `<!doctype html><html><head><meta charset="utf-8">
+<script type="module" src="/components/dvfy-button.js"></script></head>
+<body>
+  <dvfy-button id="cta" href="/cuestionario" variant="primary">Empezar</dvfy-button>
+  <dvfy-button id="plain" variant="outline">No nav</dvfy-button>
+</body></html>`;
+const DEST = `<!doctype html><html><head><meta charset="utf-8"></head>
+<body><h1 id="dest">Cuestionario</h1></body></html>`;
+
+const server = http.createServer(async (req, res) => {
+  const rel = decodeURIComponent(req.url.split('?')[0]);
+  if (rel === '/' || rel === '/index.html') { res.writeHead(200, { 'Content-Type': 'text/html' }).end(HOME); return; }
+  if (rel === '/cuestionario') { res.writeHead(200, { 'Content-Type': 'text/html' }).end(DEST); return; }
+  try {
+    const file = path.join(ROOT, rel);
+    if (!file.startsWith(ROOT)) { res.writeHead(403).end(); return; }
+    const body = await readFile(file);
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  } catch { res.writeHead(404).end('not found'); }
+});
+
+const fail = (msg) => { console.error('FAIL:', msg); process.exitCode = 1; };
+const ok = msg => console.log('  ok —', msg);
+
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+const base = `http://127.0.0.1:${port}`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const consoleErrors = [];
+page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+page.on('pageerror', e => consoleErrors.push(String(e)));
+
+try {
+  console.log(`button href e2e — ${base}\n`);
+
+  // 1. role=link semantics applied by the real component.
+  await page.goto(base + '/', { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
+  const ctaRole = await page.getAttribute('#cta', 'role');
+  const plainRole = await page.getAttribute('#plain', 'role');
+  ctaRole === 'link' ? ok('href button has role=link') : fail(`cta role=${ctaRole}, expected link`);
+  plainRole === 'button' ? ok('no-href button keeps role=button') : fail(`plain role=${plainRole}, expected button`);
+
+  // 2. Click on the href CTA REALLY navigates (no stub).
+  await Promise.all([
+    page.waitForURL('**/cuestionario'),
+    page.click('#cta'),
+  ]).catch(() => {});
+  if (page.url().endsWith('/cuestionario') && await page.$('#dest')) ok('click on href CTA navigated to /cuestionario');
+  else fail(`click did not navigate — url is ${page.url()} (DEAD CTA)`);
+
+  // 3. Enter key on the href CTA REALLY navigates.
+  await page.goto(base + '/', { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
+  await page.focus('#cta');
+  await Promise.all([
+    page.waitForURL('**/cuestionario'),
+    page.keyboard.press('Enter'),
+  ]).catch(() => {});
+  page.url().endsWith('/cuestionario') ? ok('Enter on href CTA navigated') : fail(`Enter did not navigate — url ${page.url()}`);
+
+  // 4. A plain button must NOT navigate (regression guard).
+  await page.goto(base + '/', { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
+  await page.click('#plain');
+  await page.waitForTimeout(150);
+  page.url().endsWith('/') ? ok('no-href button did NOT navigate') : fail(`plain button navigated to ${page.url()}`);
+
+  if (consoleErrors.length) fail(`console errors: ${consoleErrors.join(' | ')}`);
+  else ok('no console / page errors');
+} finally {
+  await browser.close();
+  server.close();
+}
+
+console.log(process.exitCode ? '\n✗ button href e2e FAILED' : '\n✓ button href e2e passed — CTA navigation is real');

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,22 @@ Follow studio/ standards: G&P, Verification Before Completion, citations to `stu
 
 **Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
 
-## Current Focus — devify-ui#372: Page-composition primitives (LP-Factory N1 / G2)
+## Current Focus — devify-ui#363: dvfy-button native href navigation
+
+G&P: Give `dvfy-button` first-class `href` support so the host renders/behaves as a real
+link (navigates on click + Enter, `role="link"`, supports `target`/`rel` with safe `rel`
+defaults for `target=_blank`). When `href` is absent, behavior is unchanged (a real button).
+All existing variant/size/state styling (targets the host directly) preserved — no wrapper.
+Removes the `<a pointer-events:none>` hack rueda's N5 rebuild must not carry.
+Branch: `feat/363-button-href`.
+
+- [ ] TDD: tests for href click-nav, Enter-nav, target/rel + _blank rel defaults, a11y role=link, no-href regression
+- [ ] Implement: href → role=link, navigation on click/Enter respecting target; sanitizeHref; disabled/loading suppress nav
+- [ ] JSDoc @attr for href/target/rel
+- [ ] npm run analyze (manifest), test, lint, contrast:ci green
+- [ ] PR Closes #363
+
+## Prior Focus — devify-ui#372: Page-composition primitives (LP-Factory N1 / G2)
 
 G&P: Replace rueda's ~24 invented utility classes with 4 sanctioned, manifest-declared
 light-DOM primitive families bound to EXISTING tokens — the composition vocabulary the


### PR DESCRIPTION
Closes #363.

## What
`dvfy-button` now supports first-class `href` navigation. When `href` is set, the host element renders/behaves as a real link; when absent, behavior is unchanged (a real button). Removes the consumer `<a pointer-events:none>` wrapper hack (the rueda dead-hero-CTA workaround the N5 rebuild must not carry).

## API
| attr | semantics |
|------|-----------|
| `href` | present → `role="link"`, navigates on click + Enter via `window.location.assign`; sanitized via `sanitizeHref` (rejects `javascript:`/`data:`). Absent → unchanged button (`role="button"`, Space+Enter, form submit/reset). |
| `target` | `_blank` → opens a new tab (`window.open`). |
| `rel` | applied as `window.open` features for `_blank`; **defaults to `noopener noreferrer`** when `target=_blank` and no `rel` given; an explicit `rel` is honored verbatim. |

a11y: `role=link` vs `role=button` switches with `href` (incl. dynamic add/remove). Links activate on Enter only (native anchor semantics); buttons keep Space+Enter. `disabled`/`loading` suppress navigation. Existing variant/size/state styling is fully preserved — the host stays the styled element, no wrapper.

## Verification
- `npm test` — 1460 passed, 0 failed (9 new href tests, TDD: click-nav, Enter-nav, target/rel + `_blank` rel defaults, sanitize, disabled/loading guard, no-href regression, dynamic role switch)
- `npm run lint` — green (eslint + stylelint + no-hardcoded + dvfy-preference)
- `npm run contrast:ci` — 120 pass, 0 fail
- `npm run analyze` — manifest updated (`href`/`target`/`rel`)
- **Real-browser e2e** (`npm run verify:button-href`) — drives the actual shipped component in headless Chromium and proves the CTA *actually* navigates (no stub): real click→`/cuestionario`, real Enter→nav, role=link, and a plain button does NOT navigate. Catches the exact dead-CTA regression unit tests miss.

## Scope
Button href feature only. Did not touch the composition primitives or #367.