### PR TITLE
feat(dvfy-section-hero): optional media slot (image/carousel/compare)

### DIFF
--- a/components/dvfy-section-hero.js
+++ b/components/dvfy-section-hero.js
@@ -66,23 +66,105 @@ dvfy-section-hero > [slot="trust"] {
   font-size: var(--dvfy-text-sm);
   color: var(--dvfy-text-muted);
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+   Media mode — active only when a [media-position] is set (and thus a
+   media slot is used). The no-media path above is untouched, so a hero
+   without media renders byte-identically to a text-centric hero.
+
+   Layout: in media mode the component injects a .dvfy-hero-grid descendant
+   that holds two cells — a .dvfy-hero-content cell (all text/CTA children)
+   and the [slot="media"] cell. The grid is a DESCENDANT of the hero, so its
+   @container (min-width: 48rem) query resolves against the hero's own
+   inline-size container (an element cannot query its own container-type —
+   the grid must be a child). Below 48rem it collapses to one stacked column
+   — the same container-query breakpoint the rest of the library uses
+   (cf. dvfy-grid).
+   ────────────────────────────────────────────────────────────────────── */
+dvfy-section-hero[media-position] > .dvfy-hero-grid {
+  display: grid;
+  align-items: center;
+  gap: clamp(var(--dvfy-space-8), 4vw, var(--dvfy-space-12));
+  grid-template-columns: 1fr;
+  /* Override the centered content rail — the grid spans the hero rail width. */
+  max-width: none;
+  margin-inline: 0;
+  text-align: left;
+}
+
+/* Media + content cells fill their tracks; allow shrink in grid (min-width:0). */
+dvfy-section-hero[media-position] > .dvfy-hero-grid > .dvfy-hero-content,
+dvfy-section-hero[media-position] > .dvfy-hero-grid > [slot="media"] {
+  max-width: none;
+  margin-inline: 0;
+  min-width: 0;
+}
+
+/* Content cell keeps the authored vertical rhythm between its children. */
+dvfy-section-hero[media-position] .dvfy-hero-content > :not(:first-child) {
+  margin-top: var(--dvfy-space-5);
+}
+dvfy-section-hero[media-position] .dvfy-hero-content > [slot="trust"] {
+  margin-top: var(--dvfy-space-8);
+}
+
+/* Media element sizing — consistent aspect-ratio, token radius, never overflows. */
+dvfy-section-hero[media-position] > .dvfy-hero-grid > [slot="media"] {
+  display: block;
+  width: 100%;
+  aspect-ratio: var(--dvfy-hero-media-aspect, auto);
+  border-radius: var(--dvfy-radius-lg);
+  overflow: hidden;
+}
+dvfy-section-hero[media-position] > .dvfy-hero-grid > img[slot="media"] {
+  object-fit: cover;
+  height: auto;
+}
+
+/* Two columns once the hero's container is wide enough. */
+@container (min-width: 48rem) {
+  dvfy-section-hero[media-position="left"]  > .dvfy-hero-grid,
+  dvfy-section-hero[media-position="right"] > .dvfy-hero-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  /* media-position=left → media renders in the leading column. */
+  dvfy-section-hero[media-position="left"] > .dvfy-hero-grid > [slot="media"] {
+    order: -1;
+  }
+}
+
+/* above / below — single column, media stacked relative to content. */
+dvfy-section-hero[media-position="above"] > .dvfy-hero-grid > [slot="media"] {
+  order: -1;
+}
+dvfy-section-hero[media-position="below"] > .dvfy-hero-grid > [slot="media"] {
+  order: 1;
+}
+
+/* Centered alignment override still honored in media mode. */
+dvfy-section-hero[media-position][align="center"] > .dvfy-hero-grid { text-align: center; }
 `;
 
 /**
- * Opinionated landing-page hero section: large heading, supporting body, primary CTA, optional trust strip.
+ * Opinionated landing-page hero section: large heading, supporting body, primary CTA, optional
+ * trust strip, and an optional media column (image / carousel / before-after compare slider).
  *
  * @element dvfy-section-hero
  *
- * @attr {string} align - Text alignment: left | center (default center)
+ * @attr {string} align - Text alignment: left | center (default center; media mode defaults to left)
  * @attr {string} padding - Vertical padding scale: md | lg | xl (default xl)
  * @attr {string} tone - Background tone: default | brand | muted (default default)
+ * @attr {string} media-position - Where the media slot sits relative to content: left | right | above | below. Presence of this attribute activates media (two-column) mode.
+ * @attr {string} aspect-ratio - CSS aspect-ratio for the media cell (e.g. "16 / 9"), mirrored into --dvfy-hero-media-aspect for consistent sizing.
  *
  * @slot - Hero content (heading + body + CTAs)
  * @slot trust - Optional trust-strip line below CTAs (e.g. "Trusted by 1,000+ teams")
+ * @slot media - Optional hero visual: an <img>, <dvfy-carousel>, or <dvfy-compare-slider>. Composed, not reinvented.
  *
  * @cssprop {color} --dvfy-surface-page - Default tone background
  * @cssprop {color} --dvfy-primary-bg-subtle - Brand tone background
  * @cssprop {color} --dvfy-surface-muted - Muted tone background
+ * @cssprop {string} --dvfy-hero-media-aspect - Aspect-ratio applied to the media cell (set from the aspect-ratio attribute)
  *
  * @example
  * <dvfy-section-hero tone="brand" padding="xl">
@@ -91,10 +173,86 @@ dvfy-section-hero > [slot="trust"] {
  *   <dvfy-button variant="primary" size="lg">Get started</dvfy-button>
  *   <div slot="trust">Trusted by 1,000+ teams</div>
  * </dvfy-section-hero>
+ *
+ * @example
+ * <dvfy-section-hero media-position="right" aspect-ratio="4 / 3">
+ *   <h1>See it before you buy it.</h1>
+ *   <p>Compare every angle.</p>
+ *   <dvfy-button variant="primary" size="lg">Get started</dvfy-button>
+ *   <dvfy-carousel slot="media" images='["/a.jpg","/b.jpg"]'></dvfy-carousel>
+ * </dvfy-section-hero>
  */
 class DvfySectionHero extends HTMLElement {
+  static get observedAttributes() { return ['media-position', 'aspect-ratio']; }
+
   connectedCallback() {
     injectStyles('dvfy-section-hero', STYLES);
+    this.#syncMedia();
+    this.#syncAspect();
+  }
+
+  attributeChangedCallback(name) {
+    if (!this.isConnected) return;
+    if (name === 'media-position') this.#syncMedia();
+    if (name === 'aspect-ratio') this.#syncAspect();
+  }
+
+  // Mirror the aspect-ratio attribute into a custom property — CSS cannot read an
+  // attribute value inside `aspect-ratio`, so we hand it to the media cell via a var.
+  #syncAspect() {
+    const ratio = this.getAttribute('aspect-ratio');
+    if (ratio) {
+      this.style.setProperty('--dvfy-hero-media-aspect', ratio);
+    } else {
+      this.style.removeProperty('--dvfy-hero-media-aspect');
+    }
+  }
+
+  // In media mode the component injects a .dvfy-hero-grid descendant holding two
+  // cells: a .dvfy-hero-content cell (all text/CTA children) and the [slot="media"]
+  // cell. The grid must be a DESCENDANT (not the host) so its @container query can
+  // resolve against the host's inline-size container. No media → we unwrap,
+  // restoring the exact text-centric DOM (regression-safe, byte-identical).
+  #syncMedia() {
+    const media = this.querySelector(':scope > [slot="media"], :scope > .dvfy-hero-grid > [slot="media"]');
+    const hasMedia = this.hasAttribute('media-position') && media;
+    if (hasMedia) {
+      this.#wrapMedia(media);
+    } else {
+      this.#unwrapMedia();
+    }
+  }
+
+  #wrapMedia(media) {
+    let grid = this.querySelector(':scope > .dvfy-hero-grid');
+    if (grid) return; // already in media mode — layout/order/aspect are CSS-driven
+
+    grid = document.createElement('div');
+    grid.className = 'dvfy-hero-grid';
+    const content = document.createElement('div');
+    content.className = 'dvfy-hero-content';
+
+    // Collect every non-media child into the content cell, preserving source order.
+    const children = Array.from(this.children).filter(c => c !== media);
+    for (const child of children) content.appendChild(child);
+
+    // Source order is always content→media; CSS `order` handles left/right/above/below.
+    grid.append(content, media);
+    this.appendChild(grid);
+  }
+
+  #unwrapMedia() {
+    const grid = this.querySelector(':scope > .dvfy-hero-grid');
+    if (!grid) return;
+    const content = grid.querySelector(':scope > .dvfy-hero-content');
+    // Lift content children back out, then the media element, restoring original order.
+    if (content) {
+      while (content.firstChild) this.insertBefore(content.firstChild, grid);
+      content.remove();
+    }
+    const media = grid.querySelector(':scope > [slot="media"]');
+    if (media) this.insertBefore(media, grid);
+    grid.remove();
   }
 }
 

--- a/components/dvfy-section-hero.test.js
+++ b/components/dvfy-section-hero.test.js
@@ -1,0 +1,194 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-section-hero.js';
+import './dvfy-carousel.js';
+
+describe('dvfy-section-hero', () => {
+  describe('rendering (text-centric, no media)', () => {
+    it('renders slotted heading + body content', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero>
+          <h1>Ship faster.</h1>
+          <p>Production-ready UI in one line of HTML.</p>
+        </dvfy-section-hero>
+      `);
+      expect(el.querySelector('h1').textContent).to.equal('Ship faster.');
+      expect(el.querySelector('p').textContent).to.equal('Production-ready UI in one line of HTML.');
+    });
+
+    it('renders the trust slot', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero>
+          <h1>Title</h1>
+          <div slot="trust">Trusted by 1,000+ teams</div>
+        </dvfy-section-hero>
+      `);
+      expect(el.querySelector('[slot="trust"]').textContent).to.equal('Trusted by 1,000+ teams');
+    });
+  });
+
+  describe('attributes', () => {
+    it('accepts align attribute', async () => {
+      const el = await fixture(html`<dvfy-section-hero align="left"><h1>T</h1></dvfy-section-hero>`);
+      expect(getComputedStyle(el).textAlign).to.equal('left');
+    });
+
+    it('defaults to centered text', async () => {
+      const el = await fixture(html`<dvfy-section-hero><h1>T</h1></dvfy-section-hero>`);
+      expect(getComputedStyle(el).textAlign).to.equal('center');
+    });
+
+    it('accepts padding + tone attributes without error', async () => {
+      const el = await fixture(html`<dvfy-section-hero padding="lg" tone="brand"><h1>T</h1></dvfy-section-hero>`);
+      expect(el.getAttribute('padding')).to.equal('lg');
+      expect(el.getAttribute('tone')).to.equal('brand');
+    });
+  });
+
+  describe('regression — no-media hero is unchanged', () => {
+    it('does NOT introduce a media wrapper or grid layout when no media slot is present', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero>
+          <h1>Ship faster.</h1>
+          <p>Body.</p>
+        </dvfy-section-hero>
+      `);
+      // No media slot → no two-column grid; host stays block, content rail centered.
+      expect(getComputedStyle(el).display).to.equal('block');
+      expect(el.querySelector('[slot="media"]')).to.equal(null);
+      // Direct children remain the authored content, not an injected wrapper.
+      const kids = Array.from(el.children).map(c => c.tagName.toLowerCase());
+      expect(kids).to.deep.equal(['h1', 'p']);
+    });
+  });
+
+  describe('media slot', () => {
+    it('renders an <img> placed in the media slot', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right">
+          <h1>Title</h1>
+          <p>Body</p>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      expect(media).to.exist;
+      expect(media.tagName.toLowerCase()).to.equal('img');
+      expect(media.getAttribute('alt')).to.equal('Hero');
+    });
+
+    it('renders a <dvfy-carousel> placed in the media slot', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="left">
+          <h1>Title</h1>
+          <dvfy-carousel slot="media" images='["/a.jpg","/b.jpg"]'></dvfy-carousel>
+        </dvfy-section-hero>
+      `);
+      const media = el.querySelector('dvfy-carousel[slot="media"]');
+      expect(media).to.exist;
+      expect(media.tagName.toLowerCase()).to.equal('dvfy-carousel');
+    });
+
+    it('injects a two-cell grid (content + media) when media is present', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right">
+          <h1>Title</h1>
+          <p>Body</p>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      const grid = el.querySelector(':scope > .dvfy-hero-grid');
+      expect(grid).to.exist;
+      expect(getComputedStyle(grid).display).to.equal('grid');
+      // Content children collected into the content cell; media is the sibling cell.
+      const content = grid.querySelector(':scope > .dvfy-hero-content');
+      expect(content.querySelector('h1')).to.exist;
+      expect(content.querySelector('p')).to.exist;
+      expect(grid.querySelector(':scope > [slot="media"]')).to.exist;
+    });
+
+    it('renders two grid columns at full container width (>=48rem)', async () => {
+      const el = await fixture(html`
+        <div style="width: 60rem;">
+          <dvfy-section-hero media-position="right">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const grid = el.querySelector('.dvfy-hero-grid');
+      expect(getComputedStyle(grid).gridTemplateColumns.split(' ').length).to.equal(2);
+    });
+
+    it('collapses media layout to a single column below the 48rem container breakpoint', async () => {
+      const el = await fixture(html`
+        <div style="width: 30rem;">
+          <dvfy-section-hero media-position="right">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const grid = el.querySelector('.dvfy-hero-grid');
+      // Below breakpoint → single track (stacked).
+      expect(getComputedStyle(grid).gridTemplateColumns.split(' ').length).to.equal(1);
+    });
+
+    it('orders media before content for media-position="left" at wide widths', async () => {
+      const el = await fixture(html`
+        <div style="width: 60rem;">
+          <dvfy-section-hero media-position="left">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const hero = el.querySelector('dvfy-section-hero');
+      const media = hero.querySelector('[slot="media"]');
+      // media-position=left → media column rendered first (order < content order).
+      expect(getComputedStyle(media).order).to.equal('-1');
+    });
+
+    it('does NOT pull media first for media-position="right"', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right">
+          <h1>Title</h1>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      expect(getComputedStyle(media).order).to.equal('0');
+    });
+
+    it('mirrors the aspect-ratio attribute into --dvfy-hero-media-aspect', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right" aspect-ratio="16 / 9">
+          <h1>Title</h1>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      expect(el.style.getPropertyValue('--dvfy-hero-media-aspect').trim()).to.equal('16 / 9');
+    });
+
+    it('updates the mirrored aspect-ratio when the attribute changes', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right" aspect-ratio="16 / 9">
+          <h1>Title</h1>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      el.setAttribute('aspect-ratio', '4 / 3');
+      expect(el.style.getPropertyValue('--dvfy-hero-media-aspect').trim()).to.equal('4 / 3');
+    });
+
+    it('clears the mirrored aspect-ratio when the attribute is removed', async () => {
+      const el = await fixture(html`
+        <dvfy-section-hero media-position="right" aspect-ratio="16 / 9">
+          <h1>Title</h1>
+          <img slot="media" src="/hero.jpg" alt="Hero" />
+        </dvfy-section-hero>
+      `);
+      el.removeAttribute('aspect-ratio');
+      expect(el.style.getPropertyValue('--dvfy-hero-media-aspect')).to.equal('');
+    });
+  });
+});

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2748,11 +2748,11 @@
     {
       "name": "dvfy-section-hero",
       "path": "./components/dvfy-section-hero.js",
-      "description": "Opinionated landing-page hero section: large heading, supporting body, primary CTA, optional trust strip.",
+      "description": "Opinionated landing-page hero section: large heading, supporting body, primary CTA, optional\ntrust strip, and an optional media column (image / carousel / before-after compare slider).",
       "attributes": [
         {
           "name": "align",
-          "description": "Text alignment: left | center (default center)",
+          "description": "Text alignment: left | center (default center; media mode defaults to left)",
           "type": "string"
         },
         {
@@ -2764,6 +2764,16 @@
           "name": "tone",
           "description": "Background tone: default | brand | muted (default default)",
           "type": "string"
+        },
+        {
+          "name": "media-position",
+          "description": "Where the media slot sits relative to content: left | right | above | below. Presence of this attribute activates media (two-column) mode.",
+          "type": "string"
+        },
+        {
+          "name": "aspect-ratio",
+          "description": "CSS aspect-ratio for the media cell (e.g. \"16 / 9\"), mirrored into --dvfy-hero-media-aspect for consistent sizing.",
+          "type": "string"
         }
       ],
       "slots": [
@@ -2774,6 +2784,10 @@
         {
           "name": "trust",
           "description": "Optional trust-strip line below CTAs (e.g. \"Trusted by 1,000+ teams\")"
+        },
+        {
+          "name": "media",
+          "description": "Optional hero visual: an <img>, <dvfy-carousel>, or <dvfy-compare-slider>. Composed, not reinvented."
         }
       ],
       "cssProperties": [
@@ -2791,6 +2805,11 @@
           "name": "--dvfy-surface-muted",
           "description": "Muted tone background",
           "type": "color"
+        },
+        {
+          "name": "--dvfy-hero-media-aspect",
+          "description": "Aspect-ratio applied to the media cell (set from the aspect-ratio attribute)",
+          "type": "string"
         }
       ]
     },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,27 @@ Follow studio/ standards: G&P, Verification Before Completion, citations to `stu
 
 **Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
 
-## Current Focus — devify-ui#363: dvfy-button native href navigation
+## Current Focus — devify-ui#375: optional media slot on dvfy-section-hero (WS-2a)
+
+G&P: Add an optional `media` slot to `dvfy-section-hero` accepting `<img>` / `<dvfy-carousel>` /
+`<dvfy-compare-slider>`, with `media-position` (left|right|above|below) + `aspect-ratio` layout
+control — enabling the `hero.media` A/B variant axis. No-media usage renders byte-identical to
+today (text-centric hero). Branch: `feat/375-hero-media-slot`.
+
+Design decision (design-thinking, EXISTING tokens only): CSS-only layout (component logic stays
+injectStyles + an aspect-ratio attr mirror, since CSS can't read attr values inside aspect-ratio).
+Two-column (left/right) collapses to single column below 48rem container width — reuse the
+library's `@container (min-width: 48rem)` convention (same as dvfy-grid). Column gap =
+`--dvfy-space-8` (fluid clamp like the hero's padding); media radius = `--dvfy-radius-lg`;
+aspect mirrored into `--dvfy-hero-media-aspect`.
+
+- [x] TDD: no-media regression, img render, carousel render, position attr, aspect mirror (16 tests)
+- [x] Implement: CSS layout (left|right|above|below) + container-query collapse + aspect mirror
+- [x] JSDoc @slot media + @attr media-position / aspect-ratio + @cssprop
+- [x] npm run analyze (manifest), test (1476 pass), lint, contrast:ci (120 pass) green
+- [ ] PR Closes #375
+
+## Prior Focus — devify-ui#363: dvfy-button native href navigation
 
 G&P: Give `dvfy-button` first-class `href` support so the host renders/behaves as a real
 link (navigates on click + Enter, `role="link"`, supports `target`/`rel` with safe `rel`


### PR DESCRIPTION
Closes #375 — Marketing Studio WS-2a. Adds an optional `media` slot to `dvfy-section-hero`, enabling the `hero.media` A/B variant axis.

## API
- **`media` slot** — accepts `<img>`, `<dvfy-carousel>`, or `<dvfy-compare-slider>` (composed, not reinvented).
- **`media-position="left|right|above|below"`** — layout placement of the media cell relative to content.
- **`aspect-ratio`** — CSS aspect-ratio for the media cell (e.g. `16 / 9`), mirrored into `--dvfy-hero-media-aspect` for consistent sizing (CSS can't read an attr inside `aspect-ratio`).

## How media composes
In media mode the component injects a `.dvfy-hero-grid` **descendant** holding two cells — a `.dvfy-hero-content` cell (all text/CTA children, collected) and the `[slot="media"]` cell. The grid is a descendant (not the host) so its `@container (min-width: 48rem)` two-column→single-column collapse resolves against the hero's own inline-size container (an element can't query its own container-type). Same breakpoint/convention as `dvfy-grid`. Source order is always content→media; CSS `order` handles left/right/above/below.

Bound to **existing tokens only** (design-thinking): `--dvfy-space-8/12` gap clamp, `--dvfy-radius-lg` media radius. No new tokens, no raw CSS literals.

**Regression:** no-media usage renders byte-identical to the prior text-centric hero (the grid wrapper is only injected when a media slot is present; removing `media-position` unwraps it). Covered by test.

## Verification (this session, real Chromium)
- `npm test` — **1476 passed, 0 failed** (16 new hero tests: no-media regression, img render, carousel render, two-column @≥48rem, single-column collapse @<48rem, left/right order, aspect mirror set/update/clear).
- `npm run analyze` — manifest shows slot `media`, attrs `media-position` + `aspect-ratio`, cssprop `--dvfy-hero-media-aspect`.
- `npm run lint` green (eslint + stylelint + check:tokens "no hardcoded values" + check:dvfy-pref).
- `npm run contrast:ci` — **120 pass, 0 fail** (WCAG AA).

## Scope
Only `dvfy-section-hero.js` + its new test + regenerated `custom-elements.json` (hero-only diff) + todo. No other components touched.