### PR TITLE
feat: no-nav campaign page layout for 1:1 attention ratio (WS-3b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ Three-tier token system following [UI Collective](https://uicollective.co/) meth
 `dvfy-dropdown` `dvfy-tooltip` `dvfy-tabs` `dvfy-breadcrumb` `dvfy-pagination` `dvfy-hamburger` `dvfy-sidebar` `dvfy-nav` `dvfy-tree-view` `dvfy-tree-node`
 
 ### Layout
-`dvfy-drawer` `dvfy-section` `dvfy-accordion`
+`dvfy-drawer` `dvfy-section` `dvfy-accordion` `dvfy-page-section` `dvfy-campaign-layout`
+
+> **Campaign vs site layout.** Use `dvfy-campaign-layout` for **landing / campaign pages**: it
+> is the no-nav page shell that honors Gardner's 1:1 attention ratio *by construction* — it
+> deliberately omits the nav menu so the only clickable links are the CTA(s) toward the single
+> goal (optional non-leaking brand mark only). Use `dvfy-nav-bar` for **app pages**, where a
+> multi-link nav menu is the right affordance. A landing page should never carry the site nav.
 
 ### Visual Effects
 `dvfy-scroll-reveal` `dvfy-scramble-hover` `dvfy-text-vortex` `dvfy-page-transition` `dvfy-transition-root`

--- a/catalog/data.js
+++ b/catalog/data.js
@@ -132,6 +132,11 @@ export const COMPONENT_REGISTRY = {
   'dvfy-auth':       { tier: 3, domain: 'utility',    deps: ['dvfy-modal'] },
   'dvfy-htmx-form':  { tier: 3, domain: 'forms',      deps: ['dvfy-modal'], server: true },
   'dvfy-confirm':    { tier: 3, domain: 'feedback',    deps: ['dvfy-modal'], server: true },
+
+  // ── Tier 5 — Layouts (page-level scaffolds) ───────────────────────────────
+  // No-nav campaign/landing page shell — 1:1 attention ratio by construction
+  // (deliberately omits the nav menu). Scaffolds the §8 page sections it receives.
+  'dvfy-campaign-layout': { tier: 5, domain: 'layout', deps: ['dvfy-section-hero', 'dvfy-page-section'] },
 };
 
 /** Get tags for a given tier number */

--- a/components/dvfy-campaign-layout.js
+++ b/components/dvfy-campaign-layout.js
@@ -1,0 +1,277 @@
+import { sanitizeHref } from '../utils/url.js';
+import { injectStyles } from '../utils/styles.js';
+
+/**
+ * <dvfy-campaign-layout> — No-nav landing/campaign page scaffold (Tier 5 Layout).
+ *
+ * The reusable page shell for a landing page that honors Gardner's attention ratio of
+ * 1:1 (one page, one goal) BY CONSTRUCTION. Unlike <dvfy-nav-bar>, it deliberately
+ * OMITS the site navigation menu — no nav-menu, no link list, no hamburger/drawer
+ * escape routes. Those extra clickable links leak attention (and conversions) off the
+ * single conversion path, so a campaign page must not carry them.
+ *
+ * What it provides:
+ *   - an optional non-navigational brand mark (a <header> bar) — plain text/logo, OR, if
+ *     `home-href` is set, a SINGLE self-referential link back to the page's own top
+ *     (e.g. "#top"). Never a multi-link nav.
+ *   - a <main id="main-content"> landmark holding the default slot: the §8 page sections
+ *     (compose from <dvfy-section-hero> + <dvfy-page-section> + the composition vocabulary).
+ *   - an optional <footer> (the `footer` slot) for non-nav fine print (©, legal) only.
+ *
+ * Net effect: the layout itself adds ZERO clickable links beyond the one optional brand
+ * self-link, so every other link on the page is a consumer CTA toward the one goal — the
+ * page is 1:1 by default.
+ *
+ * Attributes:
+ *   brand:     string — brand name text shown in the header (omit header entirely if absent + no logo)
+ *   logo:      string — logo image URL shown in the header
+ *   home-href: string — when set, the brand becomes a single self-link to this anchor
+ *                       (intended for "#"/page-top only; sanitized). Omit → brand is plain text.
+ *
+ * Usage:
+ *   <dvfy-campaign-layout brand="Renting Ideal" home-href="#top">
+ *     <dvfy-section-hero tone="brand" align="center">
+ *       <dvfy-heading level="1">Tu mejor renting</dvfy-heading>
+ *       <dvfy-button variant="primary" size="lg" href="/empezar">Empezar</dvfy-button>
+ *     </dvfy-section-hero>
+ *     <dvfy-page-section> … </dvfy-page-section>
+ *     <div slot="footer"><dvfy-text size="sm" tone="muted">© 2026 Renting Ideal</dvfy-text></div>
+ *   </dvfy-campaign-layout>
+ */
+
+const STYLES = `
+dvfy-campaign-layout {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 100%;
+  background: var(--dvfy-surface-page);
+  color: var(--dvfy-text-primary);
+  font-family: var(--dvfy-font-sans);
+}
+
+/* ── Skip link (a11y) — moves focus straight to the conversion content ── */
+.dvfy-campaign-layout__skip {
+  position: absolute;
+  left: -9999px;
+  top: var(--dvfy-space-2);
+  z-index: calc(var(--dvfy-z-sticky) + 1);
+  padding: var(--dvfy-space-2) var(--dvfy-space-4);
+  background: var(--dvfy-surface-raised);
+  color: var(--dvfy-text-primary);
+  font-weight: var(--dvfy-weight-semibold);
+  border-radius: 0 0 var(--dvfy-radius-md) var(--dvfy-radius-md);
+  text-decoration: none;
+}
+.dvfy-campaign-layout__skip:focus { left: var(--dvfy-space-4); }
+
+/* ── Brand bar (header) — a brand mark ONLY, never a nav menu ── */
+.dvfy-campaign-layout__header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: var(--dvfy-nav-height, 3.5rem);
+  padding-block: var(--dvfy-space-3);
+  padding-inline: clamp(var(--dvfy-space-5), 3vw, var(--dvfy-space-8));
+  background: var(--dvfy-nav-bg, var(--dvfy-surface-raised));
+  border-bottom: var(--dvfy-border-1) solid var(--dvfy-nav-border, var(--dvfy-border-default));
+}
+
+/* Inner rail caps the header content width, matching the page rail. */
+.dvfy-campaign-layout__brand {
+  display: flex;
+  align-items: center;
+  gap: var(--dvfy-space-2);
+  width: 100%;
+  max-width: var(--dvfy-container-7xl);
+  margin-inline: auto;
+  /* Plain (non-linked) brand inherits text color; the optional self-link resets below. */
+  color: var(--dvfy-nav-brand-text, var(--dvfy-text-primary));
+}
+
+/* When the brand is a self-link, keep it visually identical to the plain mark. */
+a.dvfy-campaign-layout__brand {
+  text-decoration: none;
+  color: var(--dvfy-nav-brand-text, var(--dvfy-text-primary));
+}
+
+.dvfy-campaign-layout__logo {
+  height: 1.75rem;
+  width: auto;
+  display: block;
+}
+.dvfy-campaign-layout__brand-text {
+  font-family: var(--dvfy-font-brand);
+  font-size: var(--dvfy-text-lg);
+  font-weight: var(--dvfy-weight-bold);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+/* ── Main — the single conversion path lives here ── */
+.dvfy-campaign-layout__main {
+  display: block;
+  width: 100%;
+}
+
+/* ── Footer — non-nav fine print only ── */
+.dvfy-campaign-layout__footer {
+  width: 100%;
+  box-sizing: border-box;
+  padding-block: var(--dvfy-space-8);
+  padding-inline: clamp(var(--dvfy-space-5), 3vw, var(--dvfy-space-8));
+  background: var(--dvfy-surface-muted);
+  border-top: var(--dvfy-border-1) solid var(--dvfy-border-default);
+  color: var(--dvfy-text-muted);
+  font-size: var(--dvfy-text-sm);
+}
+.dvfy-campaign-layout__footer > * {
+  max-width: var(--dvfy-container-7xl);
+  margin-inline: auto;
+}
+`;
+
+/**
+ * No-nav landing/campaign page scaffold that is 1:1 attention-ratio by construction.
+ *
+ * @element dvfy-campaign-layout
+ *
+ * @attr {string} brand - Brand name text shown in the header (header omitted if absent + no logo)
+ * @attr {string} logo - Logo image URL shown in the header
+ * @attr {string} home-href - When set, the brand becomes a single self-link to this anchor (page-top only; sanitized)
+ *
+ * @slot - Page sections (the §8 landing-page body): dvfy-section-hero, dvfy-page-section, etc.
+ * @slot footer - Non-nav fine print (©, legal). Renders a <footer> landmark.
+ *
+ * @cssprop {color} --dvfy-surface-page - Page background
+ * @cssprop {color} --dvfy-nav-bg - Brand-bar background (default: var(--dvfy-surface-raised))
+ * @cssprop {color} --dvfy-nav-border - Brand-bar bottom border (default: var(--dvfy-border-default))
+ * @cssprop {color} --dvfy-nav-brand-text - Brand text color (default: var(--dvfy-text-primary))
+ * @cssprop {length} --dvfy-nav-height - Brand-bar min height (default: 3.5rem)
+ *
+ * @example
+ * <dvfy-campaign-layout brand="Renting Ideal" home-href="#top">
+ *   <dvfy-section-hero tone="brand" align="center">
+ *     <dvfy-heading level="1">Tu mejor renting</dvfy-heading>
+ *     <dvfy-button variant="primary" size="lg" href="/empezar">Empezar</dvfy-button>
+ *   </dvfy-section-hero>
+ *   <div slot="footer"><dvfy-text size="sm" tone="muted">© 2026 Renting Ideal</dvfy-text></div>
+ * </dvfy-campaign-layout>
+ */
+class DvfyCampaignLayout extends HTMLElement {
+  static get observedAttributes() { return ['brand', 'logo', 'home-href']; }
+
+  connectedCallback() {
+    injectStyles('dvfy-campaign-layout', STYLES);
+    this.#build();
+  }
+
+  attributeChangedCallback() {
+    // Rebuild from the canonical slotted content if already built.
+    if (this.isConnected && this.#built) this.#rebuild();
+  }
+
+  #built = false;
+
+  #build() {
+    // Idempotent: if we already wrapped, do nothing (reconnection must not re-wrap).
+    if (this.querySelector(':scope > .dvfy-campaign-layout__main')) {
+      this.#built = true;
+      return;
+    }
+
+    // Partition the authored children: [slot="footer"] → footer; everything else → main.
+    const footerChildren = [];
+    const mainChildren = [];
+    for (const child of Array.from(this.childNodes)) {
+      if (child.nodeType === Node.ELEMENT_NODE && child.getAttribute('slot') === 'footer') {
+        footerChildren.push(child);
+      } else {
+        mainChildren.push(child);
+      }
+    }
+
+    while (this.firstChild) this.removeChild(this.firstChild);
+
+    // Skip-to-content link — the only structural <a> beyond the optional brand self-link,
+    // and it targets the page's OWN content (never an off-page escape route).
+    const skip = document.createElement('a');
+    skip.className = 'dvfy-campaign-layout__skip';
+    skip.href = '#main-content';
+    skip.textContent = 'Skip to content';
+    this.appendChild(skip);
+
+    // Optional brand-mark header (no nav menu — ever).
+    const header = this.#buildHeader();
+    if (header) this.appendChild(header);
+
+    // Main — the single conversion path.
+    const main = document.createElement('main');
+    main.id = 'main-content';
+    main.className = 'dvfy-campaign-layout__main';
+    for (const node of mainChildren) main.appendChild(node);
+    this.appendChild(main);
+
+    // Optional footer — non-nav fine print only.
+    if (footerChildren.length) {
+      const footer = document.createElement('footer');
+      footer.className = 'dvfy-campaign-layout__footer';
+      for (const node of footerChildren) footer.appendChild(node);
+      this.appendChild(footer);
+    }
+
+    this.#built = true;
+  }
+
+  // Rebuild on a reactive attribute change: unwrap to the authored DOM, then build again.
+  #rebuild() {
+    const main = this.querySelector(':scope > .dvfy-campaign-layout__main');
+    const footer = this.querySelector(':scope > .dvfy-campaign-layout__footer');
+    const skip = this.querySelector(':scope > .dvfy-campaign-layout__skip');
+    const header = this.querySelector(':scope > .dvfy-campaign-layout__header');
+
+    // Lift footer children back out with their slot attribute, then main children.
+    if (footer) { while (footer.firstChild) this.appendChild(footer.firstChild); footer.remove(); }
+    if (main) { while (main.firstChild) this.insertBefore(main.firstChild, footer || null); main.remove(); }
+    if (skip) skip.remove();
+    if (header) header.remove();
+
+    this.#built = false;
+    this.#build();
+  }
+
+  #buildHeader() {
+    const brandName = this.getAttribute('brand');
+    const logoUrl = this.getAttribute('logo');
+    if (!brandName && !logoUrl) return null;
+
+    const header = document.createElement('header');
+    header.className = 'dvfy-campaign-layout__header';
+
+    // Brand mark: a self-link ONLY if home-href is set; otherwise a non-interactive span.
+    const homeHref = this.getAttribute('home-href');
+    const brand = document.createElement(homeHref ? 'a' : 'div');
+    brand.className = 'dvfy-campaign-layout__brand';
+    if (homeHref) brand.setAttribute('href', sanitizeHref(homeHref));
+
+    if (logoUrl) {
+      const img = document.createElement('img');
+      img.className = 'dvfy-campaign-layout__logo';
+      img.src = sanitizeHref(logoUrl);
+      img.alt = brandName || 'Logo';
+      brand.appendChild(img);
+    }
+    if (brandName) {
+      const txt = document.createElement('span');
+      txt.className = 'dvfy-campaign-layout__brand-text';
+      txt.textContent = brandName;
+      brand.appendChild(txt);
+    }
+
+    header.appendChild(brand);
+    return header;
+  }
+}
+
+customElements.define('dvfy-campaign-layout', DvfyCampaignLayout);

--- a/components/dvfy-campaign-layout.test.js
+++ b/components/dvfy-campaign-layout.test.js
@@ -1,0 +1,161 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import './dvfy-campaign-layout.js';
+
+describe('dvfy-campaign-layout', () => {
+  it('is defined as a custom element', () => {
+    expect(customElements.get('dvfy-campaign-layout')).to.exist;
+  });
+
+  describe('page scaffold', () => {
+    it('projects default-slot content into a <main id="main-content"> landmark', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout>
+          <dvfy-section-hero><h1>Hero</h1></dvfy-section-hero>
+        </dvfy-campaign-layout>
+      `);
+      const main = el.querySelector('main#main-content');
+      expect(main, 'a single <main id="main-content"> landmark').to.exist;
+      expect(main.querySelector('dvfy-section-hero h1').textContent).to.equal('Hero');
+    });
+
+    it('renders exactly one <main> (skip-link target / single conversion path)', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout><p>body</p></dvfy-campaign-layout>
+      `);
+      expect(el.querySelectorAll('main').length).to.equal(1);
+    });
+
+    it('is a block-level element', async () => {
+      const el = await fixture(html`<dvfy-campaign-layout>x</dvfy-campaign-layout>`);
+      expect(getComputedStyle(el).display).to.equal('block');
+    });
+  });
+
+  describe('1:1 attention ratio — NO navigation menu (the whole point)', () => {
+    it('renders zero <dvfy-nav-menu> / <dvfy-nav> escape routes', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal">
+          <dvfy-button>CTA</dvfy-button>
+        </dvfy-campaign-layout>
+      `);
+      expect(el.querySelectorAll('dvfy-nav-menu, dvfy-nav').length).to.equal(0);
+    });
+
+    it('the brand bar (header) emits zero links when no home-href is given (brand is non-navigational)', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal">
+          <dvfy-button>CTA</dvfy-button>
+        </dvfy-campaign-layout>
+      `);
+      // With no consumer link and no home-href, the header adds ZERO anchors — no escape routes.
+      expect(el.querySelectorAll('header a').length).to.equal(0);
+    });
+
+    it('the only layout-owned <a> is the same-page skip link to #main-content (a11y, not a nav escape)', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal">
+          <dvfy-button>CTA</dvfy-button>
+        </dvfy-campaign-layout>
+      `);
+      // Skip link is an a11y affordance pointing at the page's OWN content — never off-page.
+      // It is the single layout-owned anchor; every other link must be a consumer CTA.
+      const layoutLinks = [...el.querySelectorAll('a')].filter(a => !a.closest('main'));
+      expect(layoutLinks.length).to.equal(1);
+      expect(layoutLinks[0].getAttribute('href')).to.equal('#main-content');
+    });
+
+    it('a plain-text brand is NOT a link', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal"><p>x</p></dvfy-campaign-layout>
+      `);
+      const brandText = el.querySelector('.dvfy-campaign-layout__brand-text');
+      expect(brandText).to.exist;
+      expect(brandText.closest('a')).to.equal(null);
+    });
+  });
+
+  describe('optional brand mark', () => {
+    it('renders no <header> when neither brand nor logo is set', async () => {
+      const el = await fixture(html`<dvfy-campaign-layout><p>x</p></dvfy-campaign-layout>`);
+      expect(el.querySelector('header')).to.equal(null);
+    });
+
+    it('renders a <header> with the brand text when brand is set', async () => {
+      const el = await fixture(html`<dvfy-campaign-layout brand="Renting Ideal"><p>x</p></dvfy-campaign-layout>`);
+      const header = el.querySelector('header');
+      expect(header).to.exist;
+      expect(header.textContent).to.contain('Renting Ideal');
+    });
+
+    it('renders a logo <img> with alt text when logo is set', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal" logo="/logo.svg"><p>x</p></dvfy-campaign-layout>
+      `);
+      const img = el.querySelector('header img');
+      expect(img).to.exist;
+      expect(img.getAttribute('alt')).to.equal('Renting Ideal');
+    });
+  });
+
+  describe('home-href — single self-referential link only', () => {
+    it('wraps the brand in exactly one self-link (header) when home-href is set', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="Renting Ideal" home-href="#top"><p>x</p></dvfy-campaign-layout>
+      `);
+      const links = el.querySelectorAll('header a');
+      expect(links.length).to.equal(1);
+      expect(links[0].getAttribute('href')).to.equal('#top');
+      expect(links[0].textContent).to.contain('Renting Ideal');
+    });
+
+    it('sanitizes a hostile home-href down to "#" (no off-page escape)', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="X" home-href="javascript:alert(1)"><p>x</p></dvfy-campaign-layout>
+      `);
+      const link = el.querySelector('header a');
+      expect(link.getAttribute('href')).to.equal('#');
+    });
+  });
+
+  describe('footer slot — non-nav fine print only', () => {
+    it('projects footer slot content into a <footer> landmark', async () => {
+      const el = await fixture(html`
+        <dvfy-campaign-layout brand="X">
+          <p>body</p>
+          <div slot="footer"><dvfy-text size="sm">© 2026 Renting Ideal</dvfy-text></div>
+        </dvfy-campaign-layout>
+      `);
+      const footer = el.querySelector('footer');
+      expect(footer).to.exist;
+      expect(footer.textContent).to.contain('© 2026 Renting Ideal');
+    });
+
+    it('renders no <footer> when the footer slot is empty', async () => {
+      const el = await fixture(html`<dvfy-campaign-layout><p>x</p></dvfy-campaign-layout>`);
+      expect(el.querySelector('footer')).to.equal(null);
+    });
+  });
+
+  describe('theming', () => {
+    it('brand bar background is bound to a semantic surface token (theme-able)', async () => {
+      // Bind the semantic token (themes supply this on <html>); assert the header consumes it.
+      document.documentElement.style.setProperty('--dvfy-surface-raised', 'rgb(1, 2, 3)');
+      const el = await fixture(html`<dvfy-campaign-layout brand="X"><p>y</p></dvfy-campaign-layout>`);
+      const bg = getComputedStyle(el.querySelector('header')).backgroundColor;
+      document.documentElement.style.removeProperty('--dvfy-surface-raised');
+      expect(bg).to.equal('rgb(1, 2, 3)');
+    });
+  });
+
+  describe('robustness', () => {
+    it('does not double-wrap on reconnection', async () => {
+      const el = await fixture(html`<dvfy-campaign-layout brand="X"><p>once</p></dvfy-campaign-layout>`);
+      el.remove();
+      document.body.appendChild(el);
+      await el.updateComplete?.catch(() => {});
+      expect(el.querySelectorAll('main').length).to.equal(1);
+      expect(el.querySelectorAll('header').length).to.equal(1);
+      expect(el.querySelectorAll('p').length).to.equal(1);
+    });
+  });
+});

--- a/components/dvfy-component-playground.js
+++ b/components/dvfy-component-playground.js
@@ -378,6 +378,7 @@ const DEFAULT_CONTENT = {
   'dvfy-drawer': '<p>Drawer body content. This panel scrolls independently and can be collapsed.</p><p style="margin-top:0.5rem;color:var(--dvfy-text-muted);font-size:var(--dvfy-text-sm)">Try the collapse button in the header.</p>',
   'dvfy-section': '<p>Section content here.</p>',
   'dvfy-section-hero': '<h1>Ship production-ready frontend, faster.</h1><p>Tier-structured Web Components with design tokens, HTMX patterns, and zero build step.</p><div style="display:flex;gap:var(--dvfy-space-3);justify-content:center;flex-wrap:wrap"><dvfy-button variant="primary" size="lg">Get started</dvfy-button><dvfy-button variant="ghost" size="lg">View on GitHub</dvfy-button></div><div slot="trust">Trusted by Devify products in production</div>',
+  'dvfy-campaign-layout': '<dvfy-section-hero tone="brand" align="center"><dvfy-heading level="1">One page, one goal</dvfy-heading><dvfy-text size="lg">A no-nav campaign shell: 1:1 attention ratio by construction — only the conversion path, no nav escape routes.</dvfy-text><dvfy-button variant="primary" size="lg">Get started</dvfy-button></dvfy-section-hero><div slot="footer"><dvfy-text size="sm" tone="muted">© 2026 Devify · Privacy · Terms</dvfy-text></div>',
   'dvfy-theme-switcher': '<option value="devify-cyan">Cyan</option><option value="devify-pink">Pink</option>',
   'dvfy-accordion': '<dvfy-section label="Section One" open><p>First section content.</p></dvfy-section><dvfy-section label="Section Two" collapsed><p>Second section content.</p></dvfy-section><dvfy-section label="Section Three" collapsed><p>Third section content.</p></dvfy-section>',
   'dvfy-carousel': '',
@@ -412,6 +413,10 @@ const DEFAULT_CONTENT = {
 
 /** Default attribute values per component — applied when selected in the playground. */
 const DEFAULT_ATTRS = {
+  'dvfy-campaign-layout': {
+    brand: 'Renting Ideal',
+    'home-href': '#top',
+  },
   'dvfy-carousel': {
     images: JSON.stringify([
       { src: '../catalog/assets/Grob.png', alt: 'Grob' },

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -405,6 +405,65 @@
       ]
     },
     {
+      "name": "dvfy-campaign-layout",
+      "path": "./components/dvfy-campaign-layout.js",
+      "description": "No-nav landing/campaign page scaffold that is 1:1 attention-ratio by construction.",
+      "attributes": [
+        {
+          "name": "brand",
+          "description": "Brand name text shown in the header (header omitted if absent + no logo)",
+          "type": "string"
+        },
+        {
+          "name": "logo",
+          "description": "Logo image URL shown in the header",
+          "type": "string"
+        },
+        {
+          "name": "home-href",
+          "description": "When set, the brand becomes a single self-link to this anchor (page-top only; sanitized)",
+          "type": "string"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Page sections (the §8 landing-page body): dvfy-section-hero, dvfy-page-section, etc."
+        },
+        {
+          "name": "footer",
+          "description": "Non-nav fine print (©, legal). Renders a <footer> landmark."
+        }
+      ],
+      "cssProperties": [
+        {
+          "name": "--dvfy-surface-page",
+          "description": "Page background",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-nav-bg",
+          "description": "Brand-bar background (default: var(--dvfy-surface-raised))",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-nav-border",
+          "description": "Brand-bar bottom border (default: var(--dvfy-border-default))",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-nav-brand-text",
+          "description": "Brand text color (default: var(--dvfy-text-primary))",
+          "type": "color"
+        },
+        {
+          "name": "--dvfy-nav-height",
+          "description": "Brand-bar min height (default: 3.5rem)",
+          "type": "length"
+        }
+      ]
+    },
+    {
       "name": "dvfy-card-glow",
       "path": "./components/dvfy-card-glow.js",
       "description": "Card with a mouse-tracked radial gradient glow that bleeds through the border.",

--- a/devify.js
+++ b/devify.js
@@ -78,6 +78,7 @@ import './components/dvfy-grid.js';
 import './components/dvfy-stack.js';
 import './components/dvfy-heading.js';
 import './components/dvfy-text.js';
+import './components/dvfy-campaign-layout.js';
 
 // Wave 4: Billing & Payments
 import './components/dvfy-usage-meter.js';

--- a/examples/campaign-layout/index.html
+++ b/examples/campaign-layout/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<!--
+  No-nav campaign page layout demo (devify-ui#377 / Marketing Studio WS-3b).
+
+  This page is the acceptance proof for dvfy-campaign-layout: a full §8-shaped landing
+  page built with the layout, rendering with a 1:1 ATTENTION RATIO — zero competing nav
+  links. The only clickable conversion paths are the CTAs toward the single goal
+  ("Empezar"). There is NO nav menu, NO link list, NO hamburger/drawer escape route.
+
+  Contrast with the site layout (dvfy-nav-bar), which carries a multi-link nav menu — an
+  app-page affordance that leaks attention on a landing page.
+
+  Composed only from the sanctioned vocabulary (dvfy-page-section / dvfy-stack / dvfy-grid
+  / dvfy-heading / dvfy-text) + existing library components (dvfy-section-hero,
+  dvfy-card-glow, dvfy-button). Zero invented utility classes.
+
+  Themed via data-theme="renting-ideal" on <html> per the integration KB.
+-->
+<html lang="es" data-theme="renting-ideal">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Renting Ideal — landing 1:1 (demo dvfy-campaign-layout)</title>
+  <meta name="description" content="Demostración de dvfy-campaign-layout: una landing sin menú de navegación, con un único camino de conversión (ratio de atención 1:1).">
+  <link rel="stylesheet" href="../../devify.css">
+  <link rel="stylesheet" href="../../tokens/themes/renting-ideal.css">
+  <script type="module" src="../../devify.js"></script>
+  <style>
+    /* Page reset only — no layout/typography utilities, those are primitives. */
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { min-height: 100%; }
+    body { background: var(--dvfy-surface-page); color: var(--dvfy-text-primary); }
+  </style>
+</head>
+<body id="top">
+  <!--
+    The whole page lives inside ONE dvfy-campaign-layout. Note what is ABSENT:
+    no dvfy-nav-bar, no dvfy-nav-menu, no dvfy-nav. The brand mark is a single
+    self-link to #top only (home-href) — not a route to other pages.
+  -->
+  <dvfy-campaign-layout brand="Renting Ideal" home-href="#top">
+
+    <!-- §8 slot 1 — HERO (single primary CTA → the one goal) -->
+    <dvfy-section-hero tone="brand" padding="xl" align="center">
+      <dvfy-heading level="1">Tu mejor renting, sin que ninguna marca te lo venda</dvfy-heading>
+      <dvfy-text size="lg">
+        Puntuamos cada coche con un Chollo Score público 0–10, fórmula determinista y auditable.
+        Gratis, sin compromiso y sin pedirte tus ingresos.
+      </dvfy-text>
+      <dvfy-button variant="primary" size="lg" href="/empezar">Empezar — 6 preguntas, &lt; 2 min</dvfy-button>
+      <div slot="trust">
+        <dvfy-text size="sm" tone="muted" inline>Imparcial · Transparente · Gratis · Sin registro</dvfy-text>
+      </div>
+    </dvfy-section-hero>
+
+    <!-- §8 slot 2 — HOW IT WORKS (no CTA — explanatory only) -->
+    <dvfy-page-section tone="default" padding="xl" align="center" width="wide">
+      <dvfy-stack gap="lg" align="center">
+        <dvfy-heading level="2">Cómo funciona</dvfy-heading>
+        <dvfy-grid cols="3" gap="lg">
+          <dvfy-card-glow padded>
+            <dvfy-heading level="3">1 · Cuéntanos</dvfy-heading>
+            <dvfy-text>Responde 6 preguntas sobre lo que necesitas. Sin registro.</dvfy-text>
+          </dvfy-card-glow>
+          <dvfy-card-glow padded>
+            <dvfy-heading level="3">2 · Puntuamos</dvfy-heading>
+            <dvfy-text>Calculamos el Chollo Score público de cada coche con la misma fórmula.</dvfy-text>
+          </dvfy-card-glow>
+          <dvfy-card-glow padded>
+            <dvfy-heading level="3">3 · Decides</dvfy-heading>
+            <dvfy-text>Te mostramos tu mejor opción. Sin pujas de marca, sin sorpresas.</dvfy-text>
+          </dvfy-card-glow>
+        </dvfy-grid>
+      </dvfy-stack>
+    </dvfy-page-section>
+
+    <!-- §8 slot 3 — OBJECTION / FAQ (no competing links) -->
+    <dvfy-page-section tone="muted" padding="xl" align="left" width="wide">
+      <dvfy-stack gap="lg">
+        <dvfy-heading level="2">¿Dónde está el truco?</dvfy-heading>
+        <dvfy-grid cols="2" gap="md">
+          <dvfy-card-glow padded>
+            <dvfy-heading level="3">¿Sois imparciales?</dvfy-heading>
+            <dvfy-text>Sí. Ninguna marca puja por aparecer. La fórmula es la misma para todos.</dvfy-text>
+          </dvfy-card-glow>
+          <dvfy-card-glow padded>
+            <dvfy-heading level="3">¿Es gratis de verdad?</dvfy-heading>
+            <dvfy-text>Gratis, sin registro y sin compromiso. La comisión la paga el proveedor, nunca tú.</dvfy-text>
+          </dvfy-card-glow>
+        </dvfy-grid>
+      </dvfy-stack>
+    </dvfy-page-section>
+
+    <!-- §8 slot 4 — RISK-REVERSAL + repeat CTA (same goal, same destination) -->
+    <dvfy-page-section tone="brand" padding="xl" align="center" width="prose">
+      <dvfy-stack gap="md" align="center">
+        <dvfy-heading level="2">Encuentra tu renting ideal</dvfy-heading>
+        <dvfy-text size="lg" tone="muted">Gratis · sin compromiso · sin registro</dvfy-text>
+        <dvfy-button variant="primary" size="lg" href="/empezar">Empezar ahora</dvfy-button>
+      </dvfy-stack>
+    </dvfy-page-section>
+
+    <!-- Footer — non-nav fine print ONLY (no links → no escape routes) -->
+    <div slot="footer">
+      <dvfy-text size="sm" tone="muted" inline>
+        © 2026 Renting Ideal · Chollo Score público y auditable · Sin afiliación de marca.
+      </dvfy-text>
+    </div>
+
+  </dvfy-campaign-layout>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch",
     "verify:composition": "node scripts/verify-composition-demo.mjs",
+    "verify:campaign-layout": "node scripts/verify-campaign-layout.mjs",
     "verify:button-href": "node scripts/verify-button-href.mjs",
     "build": "node scripts/build.js"
   }

--- a/scripts/verify-campaign-layout.mjs
+++ b/scripts/verify-campaign-layout.mjs
@@ -1,0 +1,191 @@
+/**
+ * verify-campaign-layout.mjs — real-browser e2e proof for devify-ui#377 (Marketing WS-3b).
+ *
+ * Drives the served dvfy-campaign-layout demo in headless Chromium and asserts the WHOLE
+ * POINT of the issue: the landing page renders with a 1:1 ATTENTION RATIO — zero competing
+ * nav links. The only clickable conversion paths are the consumer CTAs toward the single
+ * goal, plus the single same-page brand self-link; there is NO nav menu / nav escape route.
+ *
+ * Attention ratio (Gardner) = clickable links ÷ conversion goals; optimal 1:1. This proof:
+ *   - asserts ZERO dvfy-nav-bar / dvfy-nav-menu / dvfy-nav on the page (the layout omits them),
+ *   - counts every clickable link (real <a> + every element with role="link", e.g. dvfy-button[href]),
+ *   - asserts every off-page clickable link is a CTA pointing at the ONE goal destination,
+ *   - asserts the only same-page link is the a11y skip link + the brand self-link (#top) — not escapes,
+ *   - asserts the page is actually themed (data-theme on <html>) and free of console errors.
+ *
+ * Reuses the cached Playwright chromium. Spins up a static server on a free port.
+ *
+ * Usage: node scripts/verify-campaign-layout.mjs
+ * Exit 0 = 1:1 holds; exit 1 = a competing nav link / unthemed page / wrong link count.
+ */
+// eslint-disable-next-line import-x/no-extraneous-dependencies -- dev/CI verify tool; not part of the shipped package (scripts/ is excluded from `files`)
+import { chromium } from 'playwright';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.json': 'application/json' };
+
+// The single conversion goal on this page. Every off-page CTA must point here.
+const GOAL_DESTINATION = '/empezar';
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let rel = decodeURIComponent(req.url.split('?')[0]);
+    if (rel.endsWith('/')) rel += 'index.html';
+    const file = path.join(ROOT, rel);
+    if (!file.startsWith(ROOT)) { res.writeHead(403).end(); return; }
+    const body = await readFile(file);
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end('not found');
+  }
+});
+
+const fail = (msg) => { console.error('FAIL:', msg); process.exitCode = 1; };
+const ok = msg => console.log('  ok —', msg);
+
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+const url = `http://127.0.0.1:${port}/examples/campaign-layout/`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+
+const consoleErrors = [];
+page.on('console', (m) => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+page.on('pageerror', e => consoleErrors.push(String(e)));
+
+await page.goto(url, { waitUntil: 'networkidle' });
+await page.waitForFunction(() => customElements.get('dvfy-campaign-layout') !== undefined);
+
+console.log(`Campaign-layout e2e (1:1 attention ratio) — ${url}\n`);
+
+// 1. The layout upgraded and produced the page-scaffold landmarks.
+const scaffold = await page.evaluate(() => ({
+  defined: !!customElements.get('dvfy-campaign-layout'),
+  layouts: document.querySelectorAll('dvfy-campaign-layout').length,
+  mains: document.querySelectorAll('dvfy-campaign-layout main#main-content').length,
+  headers: document.querySelectorAll('dvfy-campaign-layout header').length,
+  footers: document.querySelectorAll('dvfy-campaign-layout footer').length,
+}));
+if (!scaffold.defined) fail('dvfy-campaign-layout did not register as a custom element');
+else ok('dvfy-campaign-layout upgraded');
+if (scaffold.layouts !== 1) fail(`expected exactly 1 dvfy-campaign-layout, found ${scaffold.layouts}`);
+else ok('exactly 1 dvfy-campaign-layout wraps the page');
+if (scaffold.mains !== 1) fail(`expected exactly 1 <main id="main-content">, found ${scaffold.mains}`);
+else ok('single <main id="main-content"> conversion landmark present');
+if (scaffold.headers !== 1) fail(`expected the brand header, found ${scaffold.headers}`);
+else ok('brand-mark <header> present');
+if (scaffold.footers !== 1) fail(`expected the footer, found ${scaffold.footers}`);
+else ok('footer (fine print) landmark present');
+
+// 2. ZERO navigation menus — the layout deliberately omits every site-nav escape route.
+const navEscape = await page.evaluate(() => ({
+  navBars: document.querySelectorAll('dvfy-nav-bar').length,
+  navMenus: document.querySelectorAll('dvfy-nav-menu').length,
+  navs: document.querySelectorAll('dvfy-nav').length,
+}));
+if (navEscape.navBars || navEscape.navMenus || navEscape.navs) {
+  fail(`competing navigation present: dvfy-nav-bar=${navEscape.navBars}, dvfy-nav-menu=${navEscape.navMenus}, dvfy-nav=${navEscape.navs}`);
+} else ok('zero dvfy-nav-bar / dvfy-nav-menu / dvfy-nav (no site-nav escape routes)');
+
+// 3. THE ATTENTION-RATIO PROOF. Enumerate every clickable link on the page:
+//    real <a> anchors + every element with role="link" (dvfy-button[href] becomes role=link).
+//    Classify each as: off-page CTA (→ the goal), same-page anchor (skip/brand self-link), or LEAK.
+const links = await page.evaluate(() => {
+  const out = [];
+  // Real anchors
+  for (const a of document.querySelectorAll('a[href]')) {
+    out.push({ kind: 'a', href: a.getAttribute('href'), text: (a.textContent || '').trim().slice(0, 40) });
+  }
+  // role="link" hosts (dvfy-button[href] etc.) that are NOT also <a>
+  for (const el of document.querySelectorAll('[role="link"]')) {
+    if (el.tagName === 'A') continue;
+    out.push({ kind: el.tagName.toLowerCase(), href: el.getAttribute('href'), text: (el.textContent || '').trim().slice(0, 40) });
+  }
+  return out;
+});
+
+const samePage = links.filter(l => l.href && l.href.startsWith('#'));
+const offPage = links.filter(l => !l.href || !l.href.startsWith('#'));
+
+console.log(`\n  link inventory — ${links.length} clickable link(s):`);
+for (const l of links) console.log(`    [${l.href && l.href.startsWith('#') ? 'same-page' : 'off-page '}] <${l.kind}> href="${l.href}" — "${l.text}"`);
+console.log('');
+
+// 3a. Every same-page link must be a non-escape anchor: the skip link (#main-content) or the
+//     brand self-link (#top). Anything else on-page that isn't one of those is suspect.
+const allowedSamePage = new Set(['#main-content', '#top']);
+const samePageLeaks = samePage.filter(l => !allowedSamePage.has(l.href));
+if (samePageLeaks.length) fail(`unexpected same-page links: ${samePageLeaks.map(l => l.href).join(', ')}`);
+else ok(`same-page links are non-escape only (${samePage.map(l => l.href).join(', ')})`);
+
+// 3b. THE CORE ASSERTION: every off-page clickable link is a CTA pointing at the ONE goal.
+//     Zero off-page link may point anywhere other than the single conversion destination.
+const goalCtas = offPage.filter(l => l.href === GOAL_DESTINATION);
+const leaks = offPage.filter(l => l.href !== GOAL_DESTINATION);
+if (leaks.length) {
+  fail(`attention-ratio LEAK — off-page link(s) not pointing at the goal (${GOAL_DESTINATION}): ${leaks.map(l => `${l.href} "${l.text}"`).join('; ')}`);
+} else {
+  ok(`every off-page link is a CTA → the single goal "${GOAL_DESTINATION}" (${goalCtas.length} CTA(s))`);
+}
+
+// 3c. Compute the attention ratio explicitly. competing links (= off-page, not the goal) ÷ goal must be 0.
+//     i.e. clickable conversion links ÷ conversion goals == CTA count ÷ 1 (the page has exactly one goal).
+const competingLinks = leaks.length;
+if (competingLinks !== 0) fail(`attention ratio is NOT 1:1 — ${competingLinks} competing link(s) leak attention`);
+else ok(`attention ratio 1:1 holds — 0 competing links; ${goalCtas.length} CTA(s) all → 1 goal`);
+
+// 3d. Sanity: there IS at least one CTA (a page with no conversion path is also wrong).
+if (goalCtas.length < 1) fail('no conversion CTA found — the single conversion path is missing');
+else ok(`${goalCtas.length} conversion CTA(s) present (the single path exists)`);
+
+// 4. Page is actually THEMED (renting-ideal on <html>), not unthemed.
+const theme = await page.evaluate(() => ({
+  dataTheme: document.documentElement.getAttribute('data-theme'),
+  headerBg: (() => {
+    const h = document.querySelector('dvfy-campaign-layout header');
+    return h ? getComputedStyle(h).backgroundColor : null;
+  })(),
+  bodyBg: getComputedStyle(document.body).backgroundColor,
+}));
+if (theme.dataTheme !== 'renting-ideal') fail(`page not themed via data-theme (got ${theme.dataTheme})`);
+else ok(`page themed: data-theme=${theme.dataTheme}, header bg=${theme.headerBg}, body bg=${theme.bodyBg}`);
+if (!theme.headerBg || theme.headerBg === 'rgba(0, 0, 0, 0)' || theme.headerBg === 'transparent') {
+  fail(`brand header background did not resolve to a token (got ${theme.headerBg})`);
+} else ok('brand header background resolves to a semantic surface token (themed, not transparent)');
+
+// 5. Zero invented dvfy-* utility classes inside the composed page (closed vocabulary holds).
+const strayClasses = await page.evaluate(() => {
+  const bad = [];
+  const allowed = new Set([
+    'dvfy-campaign-layout__skip', 'dvfy-campaign-layout__header', 'dvfy-campaign-layout__brand',
+    'dvfy-campaign-layout__brand-text', 'dvfy-campaign-layout__logo', 'dvfy-campaign-layout__main',
+    'dvfy-campaign-layout__footer',
+  ]);
+  for (const el of document.querySelectorAll('body *')) {
+    for (const c of el.classList) {
+      if (c.startsWith('dvfy-') && !allowed.has(c)) bad.push(`${el.tagName.toLowerCase()}.${c}`);
+    }
+  }
+  return bad;
+});
+if (strayClasses.length) fail(`invented/dead dvfy-* utility classes found: ${strayClasses.join(', ')}`);
+else ok('zero invented dvfy-* utility classes (only the layout BEM internals)');
+
+// 6. No console / page errors.
+if (consoleErrors.length) fail(`console/page errors: ${consoleErrors.join(' | ')}`);
+else ok('no console or page errors');
+
+await browser.close();
+server.close();
+
+if (process.exitCode === 1) {
+  console.error('\nCampaign-layout 1:1 proof FAILED.');
+} else {
+  console.log('\nCampaign-layout 1:1 proof PASSED — landing renders with a 1:1 attention ratio, zero competing nav links, fully themed.');
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,37 @@ Follow studio/ standards: G&P, Verification Before Completion, citations to `stu
 
 **Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
 
-## Current Focus — devify-ui#375: optional media slot on dvfy-section-hero (WS-2a)
+## Current Focus — devify-ui#377: no-nav campaign page layout (1:1 attention ratio, WS-3b)
+
+G&P: Ship `dvfy-campaign-layout` — a reusable Tier-5 page scaffold for landing/campaign pages
+that is 1:1 attention-ratio *by construction*: a full LP page shell with NO navigation menu, only
+the single conversion path. Optional non-leaking brand mark (unlinked, or a single self-link to
+page top `#`). Theme-able via `data-theme`, composed from the sanctioned vocabulary, zero invented
+classes. Branch: `feat/377-campaign-layout`.
+
+Why: Gardner's attention ratio = clickable links ÷ conversion goals; optimal 1:1. Site nav adds
+escape-route links that leak attention/conversions. This layout is NOT `dvfy-nav-bar` — it
+deliberately OMITS nav-menu/links/hamburger/drawer. Every clickable link on the page therefore
+comes from consumer CTA(s) → the one goal.
+
+Design decision (design-thinking, EXISTING tokens only): light-DOM injectStyles pattern; the shell
+is a `<header>` (optional brand mark) + a `<main id="main-content">` (default slot for §8 sections)
++ optional `<footer>` slot for legal/non-nav fine print. Brand bar uses `--dvfy-surface-raised` /
+`--dvfy-border-default` / `--dvfy-space-*` / `--dvfy-container-7xl` rail — same tokens as nav-bar's
+brand, minus every link. `home-href` (default absent) → brand becomes a single `href="#"`-style
+self-link to the page's own top only.
+
+- [x] Read issue + composition vocabulary + nav-bar + design-thinking skill + tokens
+- [x] TDD: dvfy-campaign-layout.test.js (brand/no-brand, self-link only, footer slot, 0 nav links) — 17 pass
+- [x] Implement components/dvfy-campaign-layout.js (light DOM, tokens only)
+- [x] Register: devify.js barrel + catalog/data.js (Tier 5 Layout) + playground DEFAULT_CONTENT/ATTRS
+- [x] Demo examples/campaign-layout/index.html (themed, §8 slots, CTAs only)
+- [x] e2e proof scripts/verify-campaign-layout.mjs — 4 links: 2 same-page non-escape + 2 CTAs→1 goal, 0 nav
+- [x] npm run analyze (manifest ✓), test (1493 ✓), lint ✓, contrast:ci (120 ✓), verify e2e ✓
+- [x] README documents campaign-vs-site layout (when to use vs dvfy-nav-bar)
+- [ ] PR Closes #377
+
+## Prior Focus — devify-ui#375: optional media slot on dvfy-section-hero (WS-2a)
 
 G&P: Add an optional `media` slot to `dvfy-section-hero` accepting `<img>` / `<dvfy-carousel>` /
 `<dvfy-compare-slider>`, with `media-position` (left|right|above|below) + `aspect-ratio` layout


### PR DESCRIPTION
Closes #377.

## What
`dvfy-campaign-layout` — a reusable **Tier-5 page scaffold** for landing/campaign pages that honors Gardner's **attention ratio of 1:1** (one page, one goal) **by construction**. Unlike `dvfy-nav-bar`, it deliberately **omits** the site nav menu — no nav-menu, no link list, no hamburger/drawer escape routes — so every clickable link on the page is a consumer CTA toward the single goal.

## API
| Attr | Purpose |
|------|---------|
| `brand` | Brand name text in the header (header omitted if absent + no logo) |
| `logo` | Logo image URL in the header |
| `home-href` | When set, the brand becomes a **single** self-link to this anchor (page-top only; sanitized) — omit → plain non-linked text |

Slots: default (the §8 page sections → `<main id="main-content">`), `footer` (non-nav fine print → `<footer>`). Light-DOM, tokens only, theme-able via `data-theme`, zero invented classes.

## How it enforces 1:1 (what it OMITS)
- Not `dvfy-nav-bar`: no nav-menu / nav links / hamburger / drawer.
- Brand mark is non-navigational by contract: plain text/img, or one self-link to the page's own top (`#`). Never off-page.
- The layout adds zero clickable links of its own beyond the optional brand self-link + the a11y skip link (`#main-content`, same-page). Every other link is a consumer CTA → the one goal.

## Demo link-count proof (real-browser e2e)
`scripts/verify-campaign-layout.mjs` drives the served demo (`examples/campaign-layout/`) in headless Chromium and enumerates every clickable link (real `<a>` + every `role="link"`, e.g. `dvfy-button[href]`):

```
link inventory — 4 clickable link(s):
  [same-page] <a> href="#main-content" — "Skip to content"
  [same-page] <a> href="#top" — "Renting Ideal"
  [off-page ] <dvfy-button> href="/empezar" — "Empezar — 6 preguntas, < 2 min"
  [off-page ] <dvfy-button> href="/empezar" — "Empezar ahora"
ok — attention ratio 1:1 holds — 0 competing links; 2 CTA(s) all → 1 goal
```

Zero `dvfy-nav-bar`/`dvfy-nav-menu`/`dvfy-nav`; both off-page links are CTAs to the single goal `/empezar`; page fully themed (`data-theme="renting-ideal"`); zero console errors. Run via `npm run verify:campaign-layout`.

## Verification (all green this session)
- `npm test` — 1493 pass
- `npm run lint` — clean (eslint + stylelint + no-hardcoded + dvfy-pref)
- `npm run contrast:ci` — 120 pass
- `npm run analyze` — manifest shows `dvfy-campaign-layout` (attrs `brand,logo,home-href`; slots default + `footer`)
- e2e 1:1 proof — PASS

## Scope
Just this layout + its test/demo/manifest/registry (devify.js barrel, catalog Tier-5 registry, playground default content) + a README note on campaign-vs-site layout. No other components modified. Pairs with WS-3c (the attention-ratio gate) + rueda adoption (WS-6).