### PR TITLE
fix(section-hero): bound + center media cell so stacked hero isn't full-bleed

### DIFF
--- a/components/dvfy-section-hero.js
+++ b/components/dvfy-section-hero.js
@@ -92,11 +92,15 @@ dvfy-section-hero[media-position] > .dvfy-hero-grid {
   text-align: left;
 }
 
-/* Media + content cells fill their tracks; allow shrink in grid (min-width:0). */
-dvfy-section-hero[media-position] > .dvfy-hero-grid > .dvfy-hero-content,
-dvfy-section-hero[media-position] > .dvfy-hero-grid > [slot="media"] {
+/* Content cell fills its track; allow shrink in grid (min-width:0).
+   The media cell is sized separately below (capped + centered), so it is not
+   reset to max-width:none here — that reset is what made it span full width. */
+dvfy-section-hero[media-position] > .dvfy-hero-grid > .dvfy-hero-content {
   max-width: none;
   margin-inline: 0;
+  min-width: 0;
+}
+dvfy-section-hero[media-position] > .dvfy-hero-grid > [slot="media"] {
   min-width: 0;
 }
 
@@ -108,10 +112,19 @@ dvfy-section-hero[media-position] .dvfy-hero-content > [slot="trust"] {
   margin-top: var(--dvfy-space-8);
 }
 
-/* Media element sizing — consistent aspect-ratio, token radius, never overflows. */
+/* Media element sizing — consistent aspect-ratio, token radius, never overflows.
+   Bounded: width is fluid (fills its track / stacked column) but capped at
+   --dvfy-hero-media-max so a stacked (above/below) media reads as a focused
+   hero visual, not a full-bleed banner, and a 2-col cell can't blow up on
+   ultrawide hosts. margin-inline:auto centers it within the leftover space
+   once capped. The cap is a consumer-overridable knob (default ~half the
+   56rem text rail) and width:100% keeps it scaling DOWN below the cap on
+   narrow viewports, never overflowing the host content box. */
 dvfy-section-hero[media-position] > .dvfy-hero-grid > [slot="media"] {
   display: block;
   width: 100%;
+  max-width: var(--dvfy-hero-media-max, var(--dvfy-container-md));
+  margin-inline: auto;
   aspect-ratio: var(--dvfy-hero-media-aspect, auto);
   border-radius: var(--dvfy-radius-lg);
   overflow: hidden;
@@ -165,6 +178,7 @@ dvfy-section-hero[media-position][align="center"] > .dvfy-hero-grid { text-align
  * @cssprop {color} --dvfy-primary-bg-subtle - Brand tone background
  * @cssprop {color} --dvfy-surface-muted - Muted tone background
  * @cssprop {string} --dvfy-hero-media-aspect - Aspect-ratio applied to the media cell (set from the aspect-ratio attribute)
+ * @cssprop {length} --dvfy-hero-media-max - Max-width cap for the media cell so a stacked (above/below) visual reads as a focused hero image rather than a full-bleed banner, and a 2-col cell can't blow up on ultrawide hosts (default --dvfy-container-md, ~28rem; width stays fluid + centered below the cap)
  *
  * @example
  * <dvfy-section-hero tone="brand" padding="xl">

--- a/components/dvfy-section-hero.test.js
+++ b/components/dvfy-section-hero.test.js
@@ -191,4 +191,108 @@ describe('dvfy-section-hero', () => {
       expect(el.style.getPropertyValue('--dvfy-hero-media-aspect')).to.equal('');
     });
   });
+
+  describe('media sizing — bounded + responsive (regression: rueda full-bleed bug)', () => {
+    // The cap defaults to var(--dvfy-container-md) (28rem = 448px). Tests provide that
+    // token on the wrapper to mirror a themed app (the token bundle isn't auto-loaded
+    // into the bare test page); the component references the real token, not a literal.
+    const MEDIA_MAX_PX = 448;
+    const TOKENS = '--dvfy-container-md: 28rem;';
+
+    it('caps stacked media (media-position="above") to a bounded max-width, not none', async () => {
+      const el = await fixture(html`
+        <div style="width: 80rem; ${TOKENS}">
+          <dvfy-section-hero media-position="above" aspect-ratio="4 / 3">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      const maxWidth = getComputedStyle(media).maxWidth;
+      expect(maxWidth).to.not.equal('none');
+      // On a very wide host the media must NOT span the full hero width.
+      expect(media.getBoundingClientRect().width).to.be.at.most(MEDIA_MAX_PX + 1);
+    });
+
+    it('caps stacked media (media-position="below") to a bounded max-width, not none', async () => {
+      const el = await fixture(html`
+        <div style="width: 80rem; ${TOKENS}">
+          <dvfy-section-hero media-position="below" aspect-ratio="4 / 3">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      expect(getComputedStyle(media).maxWidth).to.not.equal('none');
+      expect(media.getBoundingClientRect().width).to.be.at.most(MEDIA_MAX_PX + 1);
+    });
+
+    it('centers the stacked media cell (margin-inline auto)', async () => {
+      const el = await fixture(html`
+        <div style="width: 80rem; ${TOKENS}">
+          <dvfy-section-hero media-position="above">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const host = el.querySelector('dvfy-section-hero');
+      const media = el.querySelector('[slot="media"]');
+      // Geometry: a capped cell narrower than its full-width track sits centered,
+      // so the gap to the host's left edge ≈ the gap to its right edge.
+      const hostBox = host.getBoundingClientRect();
+      const mediaBox = media.getBoundingClientRect();
+      const leftGap = mediaBox.left - hostBox.left;
+      const rightGap = hostBox.right - mediaBox.right;
+      expect(leftGap).to.be.greaterThan(0);
+      expect(Math.abs(leftGap - rightGap)).to.be.lessThan(2);
+    });
+
+    it('scales the stacked media DOWN on a narrow viewport without overflowing', async () => {
+      const el = await fixture(html`
+        <div style="width: 20rem; ${TOKENS}">
+          <dvfy-section-hero media-position="above" aspect-ratio="4 / 3">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const host = el.querySelector('dvfy-section-hero');
+      const media = el.querySelector('[slot="media"]');
+      // Fluid below the cap: media width tracks down, never exceeding the host content box.
+      expect(media.getBoundingClientRect().width)
+        .to.be.at.most(host.getBoundingClientRect().width + 1);
+    });
+
+    it('bounds the 2-column media cell (media-position="right") so it cannot blow up', async () => {
+      const el = await fixture(html`
+        <div style="width: 80rem; ${TOKENS}">
+          <dvfy-section-hero media-position="right" aspect-ratio="4 / 3">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      // Even in the half-width column on a very wide host the media stays capped.
+      expect(media.getBoundingClientRect().width).to.be.at.most(MEDIA_MAX_PX + 1);
+    });
+
+    it('exposes --dvfy-hero-media-max as an overridable consumer knob', async () => {
+      const el = await fixture(html`
+        <div style="width: 80rem; ${TOKENS}">
+          <dvfy-section-hero media-position="above" aspect-ratio="4 / 3"
+                             style="--dvfy-hero-media-max: 10rem;">
+            <h1>Title</h1>
+            <img slot="media" src="/hero.jpg" alt="Hero" />
+          </dvfy-section-hero>
+        </div>
+      `);
+      const media = el.querySelector('[slot="media"]');
+      // 10rem override = 160px; media must respect it.
+      expect(media.getBoundingClientRect().width).to.be.at.most(160 + 1);
+    });
+  });
 });

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2869,6 +2869,11 @@
           "name": "--dvfy-hero-media-aspect",
           "description": "Aspect-ratio applied to the media cell (set from the aspect-ratio attribute)",
           "type": "string"
+        },
+        {
+          "name": "--dvfy-hero-media-max",
+          "description": "Max-width cap for the media cell so a stacked (above/below) visual reads as a focused hero image rather than a full-bleed banner, and a 2-col cell can't blow up on ultrawide hosts (default --dvfy-container-md, ~28rem; width stays fluid + centered below the cap)",
+          "type": "length"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test": "web-test-runner",
     "test:watch": "web-test-runner --watch",
     "verify:composition": "node scripts/verify-composition-demo.mjs",
+    "verify:hero-media": "node scripts/verify-hero-media-size.mjs",
     "verify:campaign-layout": "node scripts/verify-campaign-layout.mjs",
     "verify:button-href": "node scripts/verify-button-href.mjs",
     "build": "node scripts/build.js"

--- a/scripts/verify-hero-media-size.mjs
+++ b/scripts/verify-hero-media-size.mjs
@@ -1,0 +1,114 @@
+/**
+ * verify-hero-media-size.mjs — real-browser e2e eyeball for the dvfy-section-hero
+ * media-sizing fix (rueda "image is extremely large" / full-bleed bug).
+ *
+ * Loads the ACTUAL shipped bundle (devify.css + devify.js, complete light theme on
+ * <html data-theme>) — not the test harness — renders the hero with
+ * media-position="above" aspect-ratio="4 / 3", and proves the rendered media is
+ * bounded + centered at desktop width and scales DOWN at mobile width without
+ * overflow. Before the fix the media spanned the full ~1280px hero (full-bleed banner).
+ *
+ * Reuses the cached Playwright chromium. Spins up a static server on a free port.
+ *
+ * Usage: node scripts/verify-hero-media-size.mjs
+ * Exit 0 = bounded + responsive; exit 1 = full-bleed / overflow regression.
+ */
+// eslint-disable-next-line import-x/no-extraneous-dependencies -- dev/CI verify tool; scripts/ excluded from `files`
+import { chromium } from 'playwright';
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.json': 'application/json' };
+
+const PAGE = `<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="/devify.css" />
+  <script type="module" src="/devify.js"></script>
+</head>
+<body style="margin:0">
+  <main>
+    <dvfy-section-hero media-position="above" aspect-ratio="4 / 3" tone="brand" padding="xl">
+      <h1>See it before you buy it.</h1>
+      <p>A focused hero visual — not a full-page banner.</p>
+      <dvfy-button variant="primary" size="lg">Get started</dvfy-button>
+      <img slot="media" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600'%3E%3Crect width='800' height='600' fill='%23888'/%3E%3C/svg%3E" alt="Hero" />
+    </dvfy-section-hero>
+  </main>
+</body>
+</html>`;
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let rel = decodeURIComponent(req.url.split('?')[0]);
+    if (rel === '/' || rel === '') { res.writeHead(200, { 'Content-Type': 'text/html' }).end(PAGE); return; }
+    const file = path.join(ROOT, rel);
+    if (!file.startsWith(ROOT)) { res.writeHead(403).end(); return; }
+    const body = await readFile(file);
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end('not found');
+  }
+});
+
+const fail = (msg) => { console.error('  FAIL:', msg); process.exitCode = 1; };
+const ok = msg => console.log('  ok —', msg);
+
+await new Promise(r => server.listen(0, r));
+const port = server.address().port;
+const base = `http://localhost:${port}/`;
+
+const browser = await chromium.launch();
+try {
+  // ── Desktop: media must be bounded + centered, NOT full-bleed ──
+  const desktop = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  await desktop.goto(base);
+  await desktop.waitForFunction(() => customElements.get('dvfy-section-hero'));
+  const d = await desktop.evaluate(() => {
+    const host = document.querySelector('dvfy-section-hero');
+    const media = document.querySelector('[slot="media"]');
+    const hb = host.getBoundingClientRect();
+    const mb = media.getBoundingClientRect();
+    return {
+      maxWidth: getComputedStyle(media).maxWidth,
+      mediaW: mb.width, hostW: hb.width,
+      leftGap: mb.left - hb.left, rightGap: hb.right - mb.right,
+    };
+  });
+  if (d.maxWidth === 'none') fail(`media max-width resolved to none (token --dvfy-container-md missing?)`);
+  else ok(`media max-width resolves to ${d.maxWidth} (token-bound, not none)`);
+  // 448px cap (28rem). Full-bleed regression would be ~1216px (host minus padding).
+  if (d.mediaW > 460) fail(`desktop media is ${Math.round(d.mediaW)}px wide on a ${Math.round(d.hostW)}px hero — full-bleed banner regression`);
+  else ok(`desktop media is ${Math.round(d.mediaW)}px wide on a ${Math.round(d.hostW)}px hero — bounded, reads as a hero visual`);
+  if (Math.abs(d.leftGap - d.rightGap) > 2) fail(`media not centered (left ${Math.round(d.leftGap)} vs right ${Math.round(d.rightGap)})`);
+  else ok(`media centered (left/right gaps ≈ ${Math.round(d.leftGap)}px)`);
+
+  // ── Mobile: media scales DOWN, never overflows the host content box ──
+  const mobile = await browser.newPage({ viewport: { width: 360, height: 740 } });
+  await mobile.goto(base);
+  await mobile.waitForFunction(() => customElements.get('dvfy-section-hero'));
+  const m = await mobile.evaluate(() => {
+    const host = document.querySelector('dvfy-section-hero');
+    const media = document.querySelector('[slot="media"]');
+    return {
+      mediaW: media.getBoundingClientRect().width,
+      hostInnerW: host.clientWidth - parseFloat(getComputedStyle(host).paddingLeft) - parseFloat(getComputedStyle(host).paddingRight),
+      docOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    };
+  });
+  if (m.mediaW > m.hostInnerW + 1) fail(`mobile media (${Math.round(m.mediaW)}px) overflows host content box (${Math.round(m.hostInnerW)}px)`);
+  else ok(`mobile media is ${Math.round(m.mediaW)}px, fluid within the ${Math.round(m.hostInnerW)}px content box — scales down`);
+  if (m.docOverflow > 1) fail(`page has horizontal overflow (${m.docOverflow}px) at 360px`);
+  else ok(`no horizontal page overflow at 360px`);
+} finally {
+  await browser.close();
+  server.close();
+}
+
+if (process.exitCode) console.error('\nverify-hero-media-size: FAILED');
+else console.log('\nverify-hero-media-size: OK — hero media is bounded + responsive');

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,111 +1,20 @@
-# @devify/ui Tasks
+# Task: Fix responsive-sizing bug in dvfy-section-hero media slot
 
-**Living task list. Use atomic, verifiable items. Commit after each logical step.**
+## G&P
+- Goal: Stacked (above/below) hero media must not span full hero width; cap to a centered,
+  token-backed max-width that scales DOWN on narrow viewports without overflow. left/right
+  bounded too. No-media text hero byte-identical.
+- Purpose: rueda reported "the image is extremely large" — desktop above/below renders a
+  full-bleed banner because the media cell inherits max-width:none from the grid override.
 
-Follow studio/ standards: G&P, Verification Before Completion, citations to `studio/docs/operating-model/`, learn/ for synthesis.
+## Decision (design-thinking)
+- New cssprop --dvfy-hero-media-max, default var(--dvfy-container-md) = 28rem.
+  Flows through token system (no raw hardcoded value). ~half the 56rem text rail.
+  width:100% fluid + margin-inline:auto centered + max-width cap → never overflows.
 
-**Scope note**: This is "tools work" per `studio/shared/sergio-layout.md` Scope Rules. Coordinate with studio/ for VEmployee-impacting changes.
-
-## Current Focus — devify-ui#377: no-nav campaign page layout (1:1 attention ratio, WS-3b)
-
-G&P: Ship `dvfy-campaign-layout` — a reusable Tier-5 page scaffold for landing/campaign pages
-that is 1:1 attention-ratio *by construction*: a full LP page shell with NO navigation menu, only
-the single conversion path. Optional non-leaking brand mark (unlinked, or a single self-link to
-page top `#`). Theme-able via `data-theme`, composed from the sanctioned vocabulary, zero invented
-classes. Branch: `feat/377-campaign-layout`.
-
-Why: Gardner's attention ratio = clickable links ÷ conversion goals; optimal 1:1. Site nav adds
-escape-route links that leak attention/conversions. This layout is NOT `dvfy-nav-bar` — it
-deliberately OMITS nav-menu/links/hamburger/drawer. Every clickable link on the page therefore
-comes from consumer CTA(s) → the one goal.
-
-Design decision (design-thinking, EXISTING tokens only): light-DOM injectStyles pattern; the shell
-is a `<header>` (optional brand mark) + a `<main id="main-content">` (default slot for §8 sections)
-+ optional `<footer>` slot for legal/non-nav fine print. Brand bar uses `--dvfy-surface-raised` /
-`--dvfy-border-default` / `--dvfy-space-*` / `--dvfy-container-7xl` rail — same tokens as nav-bar's
-brand, minus every link. `home-href` (default absent) → brand becomes a single `href="#"`-style
-self-link to the page's own top only.
-
-- [x] Read issue + composition vocabulary + nav-bar + design-thinking skill + tokens
-- [x] TDD: dvfy-campaign-layout.test.js (brand/no-brand, self-link only, footer slot, 0 nav links) — 17 pass
-- [x] Implement components/dvfy-campaign-layout.js (light DOM, tokens only)
-- [x] Register: devify.js barrel + catalog/data.js (Tier 5 Layout) + playground DEFAULT_CONTENT/ATTRS
-- [x] Demo examples/campaign-layout/index.html (themed, §8 slots, CTAs only)
-- [x] e2e proof scripts/verify-campaign-layout.mjs — 4 links: 2 same-page non-escape + 2 CTAs→1 goal, 0 nav
-- [x] npm run analyze (manifest ✓), test (1493 ✓), lint ✓, contrast:ci (120 ✓), verify e2e ✓
-- [x] README documents campaign-vs-site layout (when to use vs dvfy-nav-bar)
-- [ ] PR Closes #377
-
-## Prior Focus — devify-ui#375: optional media slot on dvfy-section-hero (WS-2a)
-
-G&P: Add an optional `media` slot to `dvfy-section-hero` accepting `<img>` / `<dvfy-carousel>` /
-`<dvfy-compare-slider>`, with `media-position` (left|right|above|below) + `aspect-ratio` layout
-control — enabling the `hero.media` A/B variant axis. No-media usage renders byte-identical to
-today (text-centric hero). Branch: `feat/375-hero-media-slot`.
-
-Design decision (design-thinking, EXISTING tokens only): CSS-only layout (component logic stays
-injectStyles + an aspect-ratio attr mirror, since CSS can't read attr values inside aspect-ratio).
-Two-column (left/right) collapses to single column below 48rem container width — reuse the
-library's `@container (min-width: 48rem)` convention (same as dvfy-grid). Column gap =
-`--dvfy-space-8` (fluid clamp like the hero's padding); media radius = `--dvfy-radius-lg`;
-aspect mirrored into `--dvfy-hero-media-aspect`.
-
-- [x] TDD: no-media regression, img render, carousel render, position attr, aspect mirror (16 tests)
-- [x] Implement: CSS layout (left|right|above|below) + container-query collapse + aspect mirror
-- [x] JSDoc @slot media + @attr media-position / aspect-ratio + @cssprop
-- [x] npm run analyze (manifest), test (1476 pass), lint, contrast:ci (120 pass) green
-- [ ] PR Closes #375
-
-## Prior Focus — devify-ui#363: dvfy-button native href navigation
-
-G&P: Give `dvfy-button` first-class `href` support so the host renders/behaves as a real
-link (navigates on click + Enter, `role="link"`, supports `target`/`rel` with safe `rel`
-defaults for `target=_blank`). When `href` is absent, behavior is unchanged (a real button).
-All existing variant/size/state styling (targets the host directly) preserved — no wrapper.
-Removes the `<a pointer-events:none>` hack rueda's N5 rebuild must not carry.
-Branch: `feat/363-button-href`.
-
-- [ ] TDD: tests for href click-nav, Enter-nav, target/rel + _blank rel defaults, a11y role=link, no-href regression
-- [ ] Implement: href → role=link, navigation on click/Enter respecting target; sanitizeHref; disabled/loading suppress nav
-- [ ] JSDoc @attr for href/target/rel
-- [ ] npm run analyze (manifest), test, lint, contrast:ci green
-- [ ] PR Closes #363
-
-## Prior Focus — devify-ui#372: Page-composition primitives (LP-Factory N1 / G2)
-
-G&P: Replace rueda's ~24 invented utility classes with 4 sanctioned, manifest-declared
-light-DOM primitive families bound to EXISTING tokens — the composition vocabulary the
-LP factory's `ui:verify` gate (#305) validates against. Spec: studio
-`roadmaps/lp-factory-poc/session-2-seam-set.md` §2. Branch: `feat/372-composition-primitives`.
-
-Build (4 families, light-DOM injectStyles pattern, tokens only):
-- [ ] `dvfy-page-section` — padding=md|lg|xl (fluid clamp), align=left|center, tone=default|muted|brand, width=prose|wide|full
-- [ ] `dvfy-grid` — cols=1|2|3|4, min (auto-fit), gap=sm|md|lg; collapse to 1col below md via @container
-- [ ] `dvfy-stack` — direction=column|row, gap=sm|md|lg, justify, align
-- [ ] `dvfy-heading` (level=1|2|3) + `dvfy-text` (size=lg|md|sm, tone=muted|default) bound to type/text tokens
-- [ ] Register in devify.js + per-family .test.js
-
-Verify (Verification Before Completion):
-- [ ] `npm run analyze` → 4 families + attrs in custom-elements.json
-- [ ] Demo page composed ONLY from primitives → zero dead/unresolved classes (real-browser e2e)
-- [ ] `npm run lint` + `npm run test` + `npm run contrast:ci` green
-
-Scope guard: ONLY the 4 families + manifest + demo. NOT #363 (button href), NOT #367 (contract artifact).
-
-Token decision (design-thinking — all EXISTING, no new scales): space-* (clamps/gaps),
-type-h1/2/3-* + type-body-* + text-* (typography), surface-page/muted + primary-bg-subtle +
-text-primary/secondary/muted (tone), container-* + prose-* (width), 48rem @container collapse.
-
-## Backlog
-
-- [ ] ...
-
-## Standing Rules (from studio Operational DNA)
-
-- Atomic items only.
-- Verify with fresh evidence in this session.
-- Cite standards.
-- Escalate per criteria.
-- After work: use `studio/skills/learn/SKILL.md` for studio-valuable.
-
-See `studio/` for full constitution. This tool supports studio-scoped VEmployees.
+## DONE
+- [x] Tests first (TDD): above/below bounded (not none); narrow scales down no overflow; left/right bounded; centered; override knob; no-media regression intact
+- [x] Implement CSS: cap stacked + 2-col media cell; stop resetting media to max-width:none; expose --dvfy-hero-media-max; update @cssprop docs
+- [x] npm test (1499 pass), lint incl check:tokens (OK), contrast:ci (120 pass), analyze (manifest +5 lines, new cssprop)
+- [x] Real-bundle browser e2e (scripts/verify-hero-media-size.mjs): desktop 448px on 1280px hero + centered; mobile 320px in content box, no page overflow
+- [ ] Commit (Jorge, no AI attrib), push, open PR vs main


### PR DESCRIPTION
## The bug
With `media-position="above"` (or `below`), the injected `.dvfy-hero-grid` reset the `[slot="media"]` cell to `max-width: none`. In single-column (above/below) mode the media therefore spanned the **full hero width**, so with `aspect-ratio: 4/3` a desktop rendered an enormous full-bleed banner. Reported on rueda: *"the image is extremely large."* The 2-col `left`/`right` cells could similarly blow up on ultrawide hosts.

## The fix (`components/dvfy-section-hero.js`)
- Cap the media cell at a new cssprop **`--dvfy-hero-media-max`**, default **`var(--dvfy-container-md)` (~28rem)** — about half the 56rem text rail. Token-backed (flows through the design system, no raw literal — `check:tokens` clean).
- `width: 100%` + `margin-inline: auto` → fluid + centered; scales **down** below the cap on narrow viewports, never overflows the viewport. Honors `aspect-ratio` (CLS budget) bounded by the cap.
- Stopped resetting the media cell to `max-width: none` (the content cell keeps its reset). The **no-media text hero path is untouched — byte-identical** (regression test intact).
- Cap is a consumer-overridable knob (`--dvfy-hero-media-max`).

## Before / after sizing (real bundle, 1280px desktop hero)
| | media width | reads as |
|---|---|---|
| before | ~1216px (full hero) | full-page banner |
| after | **448px**, centered | focused hero visual |

At 360px mobile: media scales to 320px within the content box, **zero horizontal page overflow**.

## Verification (evidence)
- **TDD**: bounded-max-width (`above`/`below`, not `none`), narrow-viewport scale-down without overflow, 2-col `right` bounded, centered (geometry), `--dvfy-hero-media-max` override knob, plus the existing no-media regression. Red → green.
- `npm test` — **1499 passed, 0 failed** (real Chromium / Playwright).
- `npm run lint` (incl. `check:tokens`, `check:dvfy-pref`) — clean.
- `npm run contrast:ci` — **120 pass, 0 fail**.
- `npm run analyze` — manifest shows the new `--dvfy-hero-media-max` cssprop (scoped +5-line diff).
- **Real-bundle browser e2e** — `npm run verify:hero-media` (`scripts/verify-hero-media-size.mjs`): loads the shipped `devify.css` + `devify.js` under a complete `data-theme="light"`, asserts desktop 448px+centered and mobile no-overflow. Reuses cached chromium.

## Scope
Only `dvfy-section-hero` (+ its test, the manifest, and a new verify script wired into `package.json`). No token files changed (reuses existing `--dvfy-container-md`). Re-vendor into rueda + refresh the live demo after merge.
