### PR TITLE
fix(dvfy-stepper): idempotent #build — stop bfcache nav rail duplication

### DIFF
--- a/components/dvfy-stepper.js
+++ b/components/dvfy-stepper.js
@@ -240,6 +240,14 @@ class DvfyStepper extends HTMLElement {
   }
 
   #build() {
+    // Idempotent + bfcache-safe: a rebuild must REPLACE, not append. On
+    // disconnect→reconnect (incl. browser back/forward bfcache page restore,
+    // which re-fires connectedCallback) #build() runs again — without this,
+    // a fresh nav rail stacks on top of the previous one(s).
+    this.#nav?.removeEventListener('keydown', this.#onKey);
+    this.#nav?.remove();
+    this.querySelectorAll(':scope > .dvfy-stepper__nav').forEach(n => n.remove());
+
     this.#nav = document.createElement('div');
     this.#nav.className = 'dvfy-stepper__nav';
     this.#nav.setAttribute('role', 'tablist');

--- a/components/dvfy-stepper.test.js
+++ b/components/dvfy-stepper.test.js
@@ -167,4 +167,82 @@ describe('dvfy-stepper', () => {
       expect(el.hasAttribute('vertical')).to.be.true;
     });
   });
+
+  describe('reconnect / bfcache idempotency', () => {
+    // Regression: connectedCallback → #build() appended a fresh nav every time
+    // without removing the prior one. On disconnect→reconnect (incl. browser
+    // back/forward bfcache page restore, which fires connectedCallback again),
+    // the nav rail STACKED — a real rueda quiz showed ~5 copies after a few
+    // back/forward navigations. A rebuild must REPLACE, not append.
+
+    it('keeps exactly one nav rail after a reconnect', async () => {
+      const el = await fixture(html`
+        <dvfy-stepper active="2">
+          <dvfy-step label="One">1</dvfy-step>
+          <dvfy-step label="Two">2</dvfy-step>
+          <dvfy-step label="Three">3</dvfy-step>
+        </dvfy-stepper>
+      `);
+      await new Promise(r => setTimeout(r, 0));
+      expect(el.querySelectorAll('.dvfy-stepper__nav').length).to.equal(1);
+
+      // Simulate bfcache page restore: detach then re-attach the element,
+      // which re-fires disconnectedCallback → connectedCallback → #build().
+      const parent = el.parentNode;
+      parent.removeChild(el);
+      parent.appendChild(el);
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(el.querySelectorAll('.dvfy-stepper__nav').length).to.equal(1);
+    });
+
+    it('does not duplicate after several reconnects', async () => {
+      const el = await fixture(html`
+        <dvfy-stepper>
+          <dvfy-step label="One">1</dvfy-step>
+          <dvfy-step label="Two">2</dvfy-step>
+        </dvfy-stepper>
+      `);
+      await new Promise(r => setTimeout(r, 0));
+
+      const parent = el.parentNode;
+      for (let i = 0; i < 4; i += 1) {
+        parent.removeChild(el);
+        parent.appendChild(el);
+        await new Promise(r => setTimeout(r, 0));
+      }
+
+      expect(el.querySelectorAll('.dvfy-stepper__nav').length).to.equal(1);
+      // Headers/connectors must not stack either.
+      expect(el.querySelectorAll('.dvfy-stepper__header').length).to.equal(2);
+      expect(el.querySelectorAll('.dvfy-stepper__connector').length).to.equal(1);
+    });
+
+    it('preserves active step and step count after reconnect', async () => {
+      const el = await fixture(html`
+        <dvfy-stepper active="2">
+          <dvfy-step label="One">1</dvfy-step>
+          <dvfy-step label="Two">2</dvfy-step>
+          <dvfy-step label="Three">3</dvfy-step>
+        </dvfy-stepper>
+      `);
+      await new Promise(r => setTimeout(r, 0));
+
+      const parent = el.parentNode;
+      parent.removeChild(el);
+      parent.appendChild(el);
+      await new Promise(r => setTimeout(r, 0));
+
+      const steps = el.querySelectorAll('dvfy-step');
+      expect(steps.length).to.equal(3);
+      expect(steps[0].hasAttribute('active')).to.be.false;
+      expect(steps[1].hasAttribute('active')).to.be.true;
+      expect(steps[2].hasAttribute('active')).to.be.false;
+
+      const headers = el.querySelectorAll('.dvfy-stepper__header');
+      expect(headers.length).to.equal(3);
+      expect(headers[1].getAttribute('data-state')).to.equal('active');
+      expect(headers[1].getAttribute('aria-selected')).to.equal('true');
+    });
+  });
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,20 +1,16 @@
-# Task: Fix responsive-sizing bug in dvfy-section-hero media slot
+# Task: Fix dvfy-stepper bfcache duplication bug
 
-## G&P
-- Goal: Stacked (above/below) hero media must not span full hero width; cap to a centered,
-  token-backed max-width that scales DOWN on narrow viewports without overflow. left/right
-  bounded too. No-media text hero byte-identical.
-- Purpose: rueda reported "the image is extremely large" — desktop above/below renders a
-  full-bleed banner because the media cell inherits max-width:none from the grid override.
+**G&P:** Make `dvfy-stepper.#build()` idempotent + bfcache-safe so a reconnect
+(disconnect→reconnect, double lifecycle, or bfcache `pageshow`/persisted) yields
+exactly ONE `.dvfy-stepper__nav` rail with the correct active step preserved —
+without changing the public API, keyboard nav, a11y roles, or active-step behavior.
 
-## Decision (design-thinking)
-- New cssprop --dvfy-hero-media-max, default var(--dvfy-container-md) = 28rem.
-  Flows through token system (no raw hardcoded value). ~half the 56rem text rail.
-  width:100% fluid + margin-inline:auto centered + max-width cap → never overflows.
+## Atomic items
+- [x] Read component + existing test, understand build/lifecycle
+- [x] TDD: add failing test — reconnect → assert exactly one nav (was N), active step/count intact
+- [x] Fix: make `#build()` remove any prior generated nav before appending (idempotent)
+- [x] Verify: npm test (1502), lint, contrast:ci (120), analyze — green; manifest unchanged (API intact)
+- [x] Commit (author Jorge, no AI attribution), push, open PR vs main
 
-## DONE
-- [x] Tests first (TDD): above/below bounded (not none); narrow scales down no overflow; left/right bounded; centered; override knob; no-media regression intact
-- [x] Implement CSS: cap stacked + 2-col media cell; stop resetting media to max-width:none; expose --dvfy-hero-media-max; update @cssprop docs
-- [x] npm test (1499 pass), lint incl check:tokens (OK), contrast:ci (120 pass), analyze (manifest +5 lines, new cssprop)
-- [x] Real-bundle browser e2e (scripts/verify-hero-media-size.mjs): desktop 448px on 1280px hero + centered; mobile 320px in content box, no page overflow
-- [ ] Commit (Jorge, no AI attrib), push, open PR vs main
+## Scope guard
+ONLY dvfy-stepper (+ its test). Stop & surface if >3 files or cross-cutting change.


### PR DESCRIPTION
## The bug
`connectedCallback` → `#build()` appended a fresh `.dvfy-stepper__nav` every time, without removing the previously-built one. On **disconnect→reconnect — including browser back/forward bfcache page restore, which re-fires `connectedCallback`** — the step-header rail STACKS. A real rueda quiz showed ~5 copies after a few back/forward navigations.

## The fix
`#build()` is now idempotent + bfcache-safe: before building it removes the prior generated nav (detaching its `keydown` listener) and sweeps any stray `:scope > .dvfy-stepper__nav`, so a rebuild **replaces** rather than appends. Exactly one nav rail survives any number of reconnects.

No public API change — `custom-elements.json` manifest is unchanged. Keyboard nav, a11y roles (`role=navigation`/`tablist`/`tab`, `aria-selected`), and active-step behavior are unchanged.

## Repro / verification (TDD, before → after)
New regression block in `dvfy-stepper.test.js`, run in a real Chromium via web-test-runner:

| test | before fix | after fix |
|------|-----------|-----------|
| 1 reconnect → nav count | **2** | 1 |
| 4 reconnects → nav count | **5** | 1 |
| reconnect → header count | **6** | 3 |
| active step + count preserved after reconnect | — | active=2, 3 steps, `data-state=active` / `aria-selected=true` on step 2 |

Evidence (this session):
- `npm test` — **1502 passed, 0 failed** (81 files)
- `npm run lint` — eslint + stylelint + check:tokens + check:dvfy-pref clean
- `npm run contrast:ci` — **120 pass, 0 fail** (WCAG AA)
- `npm run analyze` — ran clean; manifest unchanged (API intact)

## Scope
Only `dvfy-stepper.js` (+ its test) and the task todo. Re-vendor into rueda after merge.