### PR TITLE
Audit: reclassify nav-bar + auth into the Widgets stratum

### DIFF
--- a/catalog/data.js
+++ b/catalog/data.js
@@ -133,10 +133,12 @@ export const COMPONENT_REGISTRY = {
   'dvfy-payment-setup':     { tier: 2, domain: 'forms',   deps: ['dvfy-button', 'dvfy-loader'] },
 
   // ── Tier 3 — Organisms (≥1 T2 dep) ────────────────────────────────────────
-  'dvfy-nav-bar':    { tier: 3, domain: 'navigation', deps: ['dvfy-nav-menu', 'dvfy-hamburger', 'dvfy-drawer'] },
-  'dvfy-auth':       { tier: 3, domain: 'utility',    deps: ['dvfy-modal'] },
   'dvfy-htmx-form':  { tier: 3, domain: 'forms',      deps: ['dvfy-modal'], server: true },
   'dvfy-confirm':    { tier: 3, domain: 'feedback',    deps: ['dvfy-modal'], server: true },
+
+  // ── Widgets stratum (self-contained sections; Domain × Role) ──────────────
+  'dvfy-nav-bar':    { strata: 'widget', domain: 'navigation', role: 'header', deps: ['dvfy-nav-menu', 'dvfy-hamburger', 'dvfy-drawer'] },
+  'dvfy-auth':       { strata: 'widget', domain: 'utility',    role: 'auth',   deps: ['dvfy-modal'] },
 
   // ── Layouts stratum (page/flow scaffolds; Category × Page-role) ───────────
   // No-nav campaign/landing page shell — 1:1 attention ratio by construction

--- a/catalog/overview.js
+++ b/catalog/overview.js
@@ -480,7 +480,7 @@ export function renderOverviewTiers(mainEl) {
 
   // ── Forcing function ──
   mainEl.appendChild(heading('The Forcing Function', 2));
-  mainEl.appendChild(para('The tier system answers one question for every component: "How deep is this component\u2019s dependency chain?" A button has zero dvfy-* dependencies (Tier 1). A nav-bar composes nav-menu, hamburger, and drawer (Tier 3). An auth form composes modal, button, and input (Tier 3).'));
+  mainEl.appendChild(para('Within Components, the tier answers one question: "How deep is its dependency chain?" A button has zero dvfy-* dependencies (Tier 1). A confirm dialog composes modal (Tier 3). Self-contained sections like nav-bar and auth are Widgets, not depth-tiered.'));
   mainEl.appendChild(para('If a component is "too complex" for its current tier, that\u2019s a signal to decompose it. Extract the reusable piece into a lower tier, then compose it. This is how the library grows without accumulating accidental complexity.'));
 
   // ── Decomposition principle ──
@@ -493,7 +493,7 @@ export function renderOverviewTiers(mainEl) {
   decompAlert.style.marginBottom = 'var(--dvfy-space-4)';
   mainEl.appendChild(decompAlert);
 
-  mainEl.appendChild(para('Example: dvfy-nav was a 521-line monolith that handled brand display, nav links, mobile drawer, and hamburger toggle. It was decomposed into three components: dvfy-nav (T1 link primitive), dvfy-nav-menu (T2 link group), and dvfy-nav-bar (T3 full bar). Each piece is independently reusable.'));
+  mainEl.appendChild(para('Example: dvfy-nav was a 521-line monolith that handled brand display, nav links, mobile drawer, and hamburger toggle. It was decomposed into three pieces: dvfy-nav (Tier 1 primitive), dvfy-nav-menu (Tier 2 composite), and the dvfy-nav-bar Widget (the full bar). Each piece is independently reusable.'));
 
   // ── Domain assignment ──
   mainEl.appendChild(heading('Domain Assignment', 2));

--- a/components/dvfy-nav-bar.js
+++ b/components/dvfy-nav-bar.js
@@ -167,7 +167,7 @@ const NAV_BAR_RESPONSIVE_FN = (id, bp) => `
 
 /**
  * Full responsive navigation bar composing lower-tier components.
- * Tier 3 organism — brand section + dvfy-nav-menu + action items.
+ * Widget (navigation / role: header) — brand section + dvfy-nav-menu + action items.
  * Mobile breakpoint triggers dvfy-hamburger toggle and dvfy-drawer slide-in.
  *
  * @element dvfy-nav-bar

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1984,7 +1984,7 @@
     {
       "name": "dvfy-nav-bar",
       "path": "./components/dvfy-nav-bar.js",
-      "description": "Full responsive navigation bar composing lower-tier components.\nTier 3 organism — brand section + dvfy-nav-menu + action items.\nMobile breakpoint triggers dvfy-hamburger toggle and dvfy-drawer slide-in.",
+      "description": "Full responsive navigation bar composing lower-tier components.\nWidget (navigation / role: header) — brand section + dvfy-nav-menu + action items.\nMobile breakpoint triggers dvfy-hamburger toggle and dvfy-drawer slide-in.",
       "attributes": [
         {
           "name": "href",

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -73,10 +73,8 @@ Components imply `strata:'component'` (they carry `tier`) — read the effective
 The live, authoritative listing is the catalog (Strata / Tier / Domain views) and `COMPONENT_REGISTRY`. Summary:
 
 - **Components** — the building blocks, Tiers 1–3 (Primitives / Composites / Organisms) across the six domains. This is the bulk of the library.
-- **Widgets** — *none registered yet.* First movers are pre-decided (pending the audit, #386): `dvfy-nav-bar` → Widget (navigation/header), `dvfy-auth` → Widget (self-contained flow). Renting Ideal's section widgets (hero, how-it-works, trust-strip, faq, footer-cta, quiz-step) land here as they are built.
+- **Widgets** — `dvfy-nav-bar` (navigation / role: header) and `dvfy-auth` (utility / role: auth), reclassified from Tier 3 in #386. Renting Ideal's section widgets (hero, how-it-works, trust-strip, faq, footer-cta, quiz-step) land here as they are built.
 - **Layouts** — `dvfy-campaign-layout` (category: landing, page-role: landing) — the no-nav 1:1-attention LP shell; the first Layout.
-
-> **Audit pending (#386):** re-classify `nav-bar`/`auth` into Widgets and reconcile per-stratum counts. Until then they remain Components in the registry.
 
 ### HTMX / server components
 


### PR DESCRIPTION
Closes #386. Bounded re-classification follow-up to the stratified-taxonomy foundation (#387, merged).

## What changed
- `dvfy-nav-bar` → **Widget** (domain: navigation, role: header) and `dvfy-auth` → **Widget** (domain: utility, role: auth), moved from Tier 3 in `catalog/data.js`. Both compose only Components, so the strict-downward composition law and the ≥1-dep forcing function hold.
- Fixed the multi-surface drift: `catalog/overview.js` examples that cited nav-bar/auth as "Tier 3" (the exact class of drift the #387 review caught) now reflect their Widget status.
- Updated the `docs/taxonomy.md` listing; removed the "audit pending" note.

## Result
- Components **69** · Widgets **2** (`nav-bar`, `auth`) · Layouts **1** (`campaign-layout`).
- Tier 3 now = `htmx-form`, `confirm`. The catalog **Strata** view now populates the Widgets section.

## Verification
- `npm run check:taxonomy` green (widgets compose only components + ≥1 dep).
- `npm run lint` green · `npm run test` **1502 passed** · `npm run analyze` no-op (no component API touched).