### PR TITLE
feat(themes): promote devify-dark upstream with calmer header/footer surfaces

### DIFF
--- a/scripts/check-contrast.js
+++ b/scripts/check-contrast.js
@@ -159,6 +159,7 @@ function loadThemes() {
   const cyanCss       = readFileSync(join(ROOT, 'tokens/themes/devify-cyan.css'), 'utf8');
   const pinkCss       = readFileSync(join(ROOT, 'tokens/themes/devify-pink.css'), 'utf8');
   const rentingCss    = readFileSync(join(ROOT, 'tokens/themes/renting-ideal.css'), 'utf8');
+  const devifyDarkCss = readFileSync(join(ROOT, 'tokens/themes/devify-dark.css'), 'utf8');
 
   const primitives    = parseCssVars(primitivesCss);
   const lightVars     = extractSelectorVars(lightCss, ':root');
@@ -169,6 +170,7 @@ function loadThemes() {
   const pinkDarkVars  = extractSelectorVars(pinkCss, '[data-theme="devify-pink-dark"]');
   const rentingVars     = extractSelectorVars(rentingCss, '[data-theme="renting-ideal"]');
   const rentingDarkVars = extractSelectorVars(rentingCss, '[data-theme="renting-ideal-dark"]');
+  const devifyDarkVars  = extractSelectorVars(devifyDarkCss, '[data-theme="devify-dark"]');
 
   // Merge strategy: primitives (:root) → light semantic base → theme overrides.
   // Partial brand themes (cyan/pink) only override their accent colours;
@@ -185,6 +187,10 @@ function loadThemes() {
     'devify-pink-dark': { ...primitives, ...lightVars, ...pinkDarkVars },
     'renting-ideal':      { ...primitives, ...rentingVars },
     'renting-ideal-dark': { ...primitives, ...rentingDarkVars },
+    // devify-dark is a FULL semantic theme (indigo surfaces + cyan/pink brand) over the
+    // primitive base. Its surface-raised/muted use color-mix (unresolvable to a single hex),
+    // but those are not in the audited PAIRS — every checked pair resolves via single var().
+    'devify-dark':        { ...primitives, ...devifyDarkVars },
   };
 }
 

--- a/tokens/themes/devify-dark.css
+++ b/tokens/themes/devify-dark.css
@@ -1,0 +1,151 @@
+/*
+ * @devify/ui — Devify Dark Theme (devify-dark)
+ *
+ * The Devify studio DARK brand theme: Devify cyan (#00E5E5) + hot-pink (#FF3CAC)
+ * accents on a deep-indigo (#1A1040 family) base. Activate with
+ * data-theme="devify-dark" on <html>.
+ *
+ * Promoted upstream (devify-ui#—) from a page-local Tier-2 theme in `projects/devify-me`.
+ * The library already ships a neutral-slate `dark` and a cyan-forward `devify-cyan-dark`,
+ * but NEITHER pairs the indigo surface family with the cyan+pink accents the studio brand
+ * uses. This is that missing "dark brand" combo, authored as a full SEMANTIC (Tier-2) theme:
+ * every role token maps onto existing Tier-1 primitives (indigo/cyan/brand/neutral) — no raw
+ * color literals, no component patches. Consumed by name (a standalone by-name brand theme,
+ * like `renting-ideal.css`); NOT auto-imported into devify.css.
+ *
+ * ── SURFACE RAMP (calmer-surfaces tweak, devify-ui#—) ──────────────────────────
+ * The raised/muted surfaces (chum-page header via --dvfy-nav-bg→--dvfy-surface-raised,
+ * footer via --dvfy-surface-muted) previously mapped to indigo-900 (#1f1558), which reads
+ * noticeably brighter than the indigo-950 (#1a1040) page and pops too much. They now sit a
+ * SMALL step above the page via a primitive-derived color-mix (page 60% + indigo-900 40%),
+ * for a calmer, more premium dark UI. The step stays distinguishable (not flush, not black);
+ * the existing indigo-800 hairline border further delineates header/footer.
+ *   --dvfy-surface-raised:  indigo-900 #1f1558  →  mix(indigo-950 60%, indigo-900)  [darker]
+ *   --dvfy-surface-muted:   indigo-900 #1f1558  →  mix(indigo-950 60%, indigo-900)  [darker]
+ * Brand cyan/pink, text, borders and all other roles are unchanged. Darkening a dark-theme
+ * surface only INCREASES contrast for the light foregrounds on it, so WCAG-AA is preserved.
+ *
+ * Contrast (WCAG AA — foreground vs surface):
+ *   text-primary  neutral-50  #f8fafc  on page/raised/muted (indigo)   → ~16:1  (AAA)
+ *   text-muted    neutral-300 #cbd5e1  on muted (footer fine print)     → ~12:1  (AAA)
+ *   primary CTA   neutral-950 #020617  on cyan-500 #00e5e5              → ~13:1  (AAA)
+ */
+
+[data-theme="devify-dark"] {
+  /* ─── Surface — indigo brand base (the deep-indigo studio dark) ─── */
+  --dvfy-surface-page:      var(--dvfy-indigo-950);   /* #1a1040 — page */
+  /* Raised (cards, chum header) — a SMALL calm step above the page, not full indigo-900. */
+  --dvfy-surface-raised:    color-mix(in oklch, var(--dvfy-indigo-950) 60%, var(--dvfy-indigo-900));
+  --dvfy-surface-overlay:   var(--dvfy-indigo-800);
+  --dvfy-surface-sunken:    var(--dvfy-neutral-1000); /* #000000 — deepest well */
+  /* Muted (alternating sections, chum footer) — same calm step as raised. */
+  --dvfy-surface-muted:     color-mix(in oklch, var(--dvfy-indigo-950) 60%, var(--dvfy-indigo-900));
+
+  /* ─── Overlay scrims ─── */
+  --dvfy-overlay-bg-subtle: rgb(0 0 0 / 0.3);
+  --dvfy-overlay-bg:        rgb(0 0 0 / 0.5);
+  --dvfy-overlay-bg-strong: rgb(0 0 0 / 0.75);
+
+  /* ─── Elevation surfaces (progressive lightening, indigo-tinted) ─── */
+  --dvfy-elevation-2xs-bg:  var(--dvfy-indigo-950);
+  --dvfy-elevation-xs-bg:   color-mix(in oklch, var(--dvfy-indigo-900) 70%, var(--dvfy-indigo-800));
+  --dvfy-elevation-sm-bg:   var(--dvfy-indigo-900);
+  --dvfy-elevation-md-bg:   color-mix(in oklch, var(--dvfy-indigo-900) 40%, var(--dvfy-indigo-800));
+  --dvfy-elevation-lg-bg:   var(--dvfy-indigo-800);
+  --dvfy-elevation-xl-bg:   color-mix(in oklch, var(--dvfy-indigo-800) 50%, var(--dvfy-indigo-700));
+  --dvfy-elevation-2xl-bg:  var(--dvfy-indigo-700);
+
+  /* ─── Elevation shadows (boosted for dark) ─── */
+  --dvfy-shadow-2xs: 0 1px 2px 0 color-mix(in srgb, var(--dvfy-shadow-color) 10%, transparent);
+  --dvfy-shadow-xs:  0 1px 3px 0 color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent),
+                     0 1px 2px -1px color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent);
+  --dvfy-shadow-sm:  0 2px 4px -1px color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent),
+                     0 1px 3px -1px color-mix(in srgb, var(--dvfy-shadow-color) 12%, transparent);
+  --dvfy-shadow-md:  0 4px 6px -1px color-mix(in srgb, var(--dvfy-shadow-color) 20%, transparent),
+                     0 2px 4px -2px color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent);
+  --dvfy-shadow-lg:  0 10px 15px -3px color-mix(in srgb, var(--dvfy-shadow-color) 20%, transparent),
+                     0 4px 6px -4px color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent);
+  --dvfy-shadow-xl:  0 20px 25px -5px color-mix(in srgb, var(--dvfy-shadow-color) 20%, transparent),
+                     0 8px 10px -6px color-mix(in srgb, var(--dvfy-shadow-color) 15%, transparent);
+  --dvfy-shadow-2xl: 0 25px 35px -10px color-mix(in srgb, var(--dvfy-shadow-color) 30%, transparent);
+
+  /* ─── Text — bright on indigo; "muted" bumped to neutral-300 for AA on this base
+         (LP body paragraphs use tone="muted", so they must read at secondary contrast,
+         not caption-dim). ─── */
+  --dvfy-text-primary:      var(--dvfy-neutral-50);   /* #f8fafc */
+  --dvfy-text-secondary:    var(--dvfy-neutral-200);  /* #e2e8f0 */
+  --dvfy-text-muted:        var(--dvfy-neutral-300);  /* #cbd5e1 — AA-safe body on indigo */
+  --dvfy-text-disabled:     var(--dvfy-neutral-500);
+  --dvfy-text-inverse:      var(--dvfy-neutral-900);
+  --dvfy-text-link:         var(--dvfy-cyan-300);     /* bright cyan link on dark */
+  --dvfy-text-link-hover:   var(--dvfy-cyan-200);
+
+  /* ─── Border — indigo-tinted hairlines so cards read as one family ─── */
+  --dvfy-border-default:    var(--dvfy-indigo-800);
+  --dvfy-border-strong:     var(--dvfy-indigo-700);
+  --dvfy-border-muted:      var(--dvfy-indigo-900);
+  --dvfy-border-focus:      var(--dvfy-cyan-400);
+
+  /* ─── Primary (Devify cyan) — the CTA. Dark text on bright cyan = max contrast. ─── */
+  --dvfy-primary-bg:        var(--dvfy-cyan-500);     /* #00e5e5 */
+  --dvfy-primary-bg-hover:  var(--dvfy-cyan-400);
+  --dvfy-primary-bg-active: var(--dvfy-cyan-300);
+  --dvfy-primary-bg-subtle: var(--dvfy-indigo-900);   /* brand-tone section wash, on-base */
+  --dvfy-primary-text:      var(--dvfy-neutral-950);  /* #020617 on cyan */
+  --dvfy-primary-border:    var(--dvfy-cyan-500);
+
+  /* ─── Accent (Devify hot pink) — the second brand pop (icons, accents) ─── */
+  --dvfy-accent-bg:         var(--dvfy-brand-500);    /* #ff3cac */
+  --dvfy-accent-bg-hover:   var(--dvfy-brand-400);
+  --dvfy-accent-bg-subtle:  var(--dvfy-brand-950);
+  --dvfy-accent-text:       var(--dvfy-brand-300);    /* readable pink on dark */
+  --dvfy-accent-border:     var(--dvfy-brand-700);
+
+  /* ─── Status — keep semantic hues, dark-tuned ─── */
+  --dvfy-success-bg:        var(--dvfy-green-600);
+  --dvfy-success-bg-subtle: var(--dvfy-green-950);
+  --dvfy-success-text:      var(--dvfy-green-300);
+  --dvfy-success-border:    var(--dvfy-green-700);
+  --dvfy-warning-bg:        var(--dvfy-amber-600);
+  --dvfy-warning-bg-subtle: var(--dvfy-amber-950);
+  --dvfy-warning-text:      var(--dvfy-amber-300);
+  --dvfy-warning-border:    var(--dvfy-amber-700);
+  --dvfy-danger-bg:         var(--dvfy-red-600);
+  --dvfy-danger-bg-subtle:  var(--dvfy-red-950);
+  --dvfy-danger-text:       var(--dvfy-red-300);
+  --dvfy-danger-border:     var(--dvfy-red-700);
+  /* Info alert (the "free teardown" banner) — cyan family on indigo wash */
+  --dvfy-info-bg:           var(--dvfy-cyan-600);
+  --dvfy-info-bg-subtle:    var(--dvfy-indigo-900);
+  --dvfy-info-text:         var(--dvfy-cyan-200);
+  --dvfy-info-border:       var(--dvfy-cyan-700);
+
+  /* ─── Interactive states ─── */
+  --dvfy-hover-bg:          var(--dvfy-indigo-800);
+  --dvfy-active-bg:         var(--dvfy-indigo-700);
+  --dvfy-selected-bg:       var(--dvfy-indigo-900);
+  --dvfy-disabled-bg:       var(--dvfy-indigo-900);
+  --dvfy-disabled-text:     var(--dvfy-neutral-500);
+
+  /* ─── Focus ring ─── */
+  --dvfy-ring-color:        var(--dvfy-cyan-400);
+
+  /* ─── Input (the free-teardown form) — indigo well, cyan focus ─── */
+  --dvfy-input-bg:          var(--dvfy-indigo-900);
+  --dvfy-input-border:      var(--dvfy-indigo-700);
+  --dvfy-input-border-hover: var(--dvfy-indigo-600);
+  --dvfy-input-border-focus: var(--dvfy-cyan-400);
+  --dvfy-input-placeholder: var(--dvfy-neutral-400);
+  --dvfy-input-error:       var(--dvfy-red-400);
+
+  /* ─── Status text on solid backgrounds ─── */
+  --dvfy-on-success:        var(--dvfy-neutral-950);
+  --dvfy-on-warning:        var(--dvfy-neutral-950);
+  --dvfy-on-danger:         var(--dvfy-neutral-0);
+  --dvfy-on-info:           var(--dvfy-neutral-950);
+
+  /* ─── Tooltip ─── */
+  --dvfy-tooltip-bg:        var(--dvfy-neutral-100);
+  --dvfy-tooltip-text:      var(--dvfy-neutral-900);
+  --dvfy-tooltip-border:    var(--dvfy-neutral-300);
+}


### PR DESCRIPTION
## What

Promotes the **devify-dark** studio brand theme (deep-indigo `#1A1040` base + Devify cyan/pink accents) into `@devify/ui` as a first-class named theme at `tokens/themes/devify-dark.css`, and applies the requested **surface-calming** tweak so the chum-page header/footer sit closer to the page background.

### Why a promotion (locating the theme)
`devify-dark` did **not** previously exist in `@devify/ui` — it lived only as a page-local Tier-2 theme in `projects/devify-me/assets/theme-devify-dark.css`. Per the token discipline (no local overrides that belong in the design system — fix upstream) and the existing `renting-ideal.css` precedent (a consuming-project brand theme promoted upstream, consumed by name), the correct fix is to promote it. The `--dvfy-indigo-*` primitives it needs already ship in `tokens/colors.css`, so the port is clean.

Like `renting-ideal.css`, it is a **by-name** brand theme: **not** auto-imported into `devify.css` (won't grow the base bundle / won't apply globally). Consumers link it via `data-theme="devify-dark"`.

## The surface darkening (the actual ask)

The raised/muted surfaces drive the chum-page header (`--dvfy-nav-bg` → `--dvfy-surface-raised`) and footer (`--dvfy-surface-muted`, see `utils/no-nav-shell.js`). They previously mapped to `indigo-900 #1f1558`, noticeably brighter than the `indigo-950 #1a1040` page — so they popped too much.

| Token | Before | After | Notes |
|---|---|---|---|
| `--dvfy-surface-raised` | `indigo-900` `#1f1558` `rgb(31,21,88)` | `color-mix(in oklch, indigo-950 60%, indigo-900)` → **`#1c1249` `rgb(28,18,73)`** | header |
| `--dvfy-surface-muted` | `indigo-900` `#1f1558` `rgb(31,21,88)` | same mix → **`#1c1249`** | footer |
| `--dvfy-surface-page` | `indigo-950` `#1a1040` | (unchanged) | page |

The new surface is a **small step above the page**, not flush and not black; the existing `indigo-800` hairline border further delineates header/footer. **Brand cyan/pink, text, and all other roles are unchanged.** No raw hex — the step is derived from the indigo primitive scale via `color-mix`, matching the theme's existing elevation ramp. Conservative starting point — easy to fine-tune darker/lighter.

## WCAG-AA evidence

Darkening a dark-theme surface only **increases** contrast for the light foregrounds on it. Verified:

- **`npm run contrast`** — `devify-dark` registered in the checker: **15/15 pass, 0 fail** (all AA/AAA; audited pairs use `--dvfy-surface-page`).
- **Browser e2e (Playwright, cached chromium)** — real chum page under `data-theme="devify-dark"`:
  - page themed: body `#1a1040` (not unthemed)
  - header + footer resolve to `#1c1249` — **darker than old `#1f1558`**, one step above page
  - **brand text 16.29:1** on header (neutral-50); **footer fine-print 11.48:1** (neutral-300) — both AAA
  - live CTA (`dvfy-button[type=submit]`, role=button, in a form with `action`), zero nav links, skip-link → `#main-content` (1:1 attention preserved), no JS errors

## Checks

- `npm run lint` (eslint + stylelint + check:tokens + check:dvfy-pref + check:taxonomy) — green
- `npm run test` — **1578 pass, 0 fail** (chromium)
- `custom-elements.json` not regenerated — no component API change (theme-token only)

## Downstream note
A **devify-me re-vendor** will pick this up (handled downstream, not in this PR — devify-me untouched). devify-me can then drop its page-local `assets/theme-devify-dark.css` and link the vendored upstream theme.

> **Reviewer flag:** the upstream port is **color/surface only** — I intentionally **dropped the devify-me theme's brand TYPOGRAPHY block** (Saira `@font-face`-dependent `--dvfy-font-brand`/`--dvfy-font-display`), since a library named theme shouldn't embed one project's fonts the library doesn't ship (matches `renting-ideal.css`, which is color-only). devify-me should keep those font tokens in its page layer, or they can be added upstream separately with proper `@font-face`.