### PR TITLE
fix(radio,checkbox): activate from anywhere on the host, not just the input

### DIFF
--- a/components/dvfy-checkbox.js
+++ b/components/dvfy-checkbox.js
@@ -170,6 +170,8 @@ class DvfyCheckbox extends HTMLElement {
   #initialized = false;
   #muted = false;
   #id = '';
+  /** Guards against re-binding the host click handler if the element is re-connected. */
+  #hostActivationBound = false;
 
   connectedCallback() {
     injectStyles('dvfy-checkbox', STYLES);
@@ -182,8 +184,39 @@ class DvfyCheckbox extends HTMLElement {
       this.#state = 'unchecked';
     }
     this.setAttribute('role', 'checkbox');
+    this.#bindHostActivation();
     this.#build();
     this.#initialized = true;
+  }
+
+  /**
+   * Make the WHOLE host activate the input, not just the input and its label text.
+   *
+   * The host sets `cursor: pointer`, promising the entire element is clickable, but the input
+   * and label are siblings inside it — so any host area outside those two (the padding a
+   * consumer adds to render a full-width card row) swallowed the click. Hover styling covered
+   * the whole row while the hit target did not.
+   *
+   * Bound once on the host (never in #build, which reruns on attribute changes) and guarded so
+   * a forwarded click cannot re-enter: input.click() dispatches a click targeting the input,
+   * which bubbles back here and returns early. Tristate cycling is unaffected — it is driven by
+   * the input's own click handler, which this simply triggers.
+   */
+  #bindHostActivation() {
+    if (this.#hostActivationBound) return;
+    this.#hostActivationBound = true;
+
+    this.addEventListener('click', (event) => {
+      if (this.hasAttribute('disabled')) return;
+
+      const input = this.querySelector('.dvfy-checkbox__input');
+      if (!input) return;
+
+      if (event.target === input) return;
+      if (event.target.closest?.('.dvfy-checkbox__label')) return;
+
+      input.click();
+    });
   }
 
   disconnectedCallback() {

--- a/components/dvfy-checkbox.test.js
+++ b/components/dvfy-checkbox.test.js
@@ -1,4 +1,4 @@
-import { fixture, html, expect, oneEvent } from '@open-wc/testing';
+import { fixture, html, expect, nextFrame, oneEvent } from '@open-wc/testing';
 import { checkA11y } from '../utils/axe-test.js';
 import './dvfy-checkbox.js';
 
@@ -202,6 +202,66 @@ describe('dvfy-checkbox', () => {
       await Promise.resolve();
       expect(el.querySelector('.dvfy-checkbox__input')).to.equal(input);
       expect(input.indeterminate).to.be.true;
+    });
+  });
+
+  describe('whole-host activation', () => {
+    // Same contract as dvfy-radio: the host promises clickability via cursor:pointer, and
+    // consumers pad it into a full-width row, so the entire host must toggle.
+    it('toggles when the host padding (not the input or label) is clicked', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t" label="Accept"></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+      expect(input.checked).to.be.false;
+
+      el.click();
+
+      expect(input.checked).to.be.true;
+    });
+
+    // Forwarding must not multiply events: a host click and a direct input click have to
+    // produce the SAME number of change events. (The component emits two today — its own
+    // re-dispatch plus the native one bubbling — which is a separate pre-existing defect;
+    // asserting parity guards this fix without freezing that bug in place.)
+    it('a host click emits the same number of change events as a direct input click', async () => {
+      const direct = await fixture(html`<dvfy-checkbox name="t" label="Accept"></dvfy-checkbox>`);
+      let directCount = 0;
+      direct.addEventListener('change', () => { directCount += 1; });
+      direct.querySelector('.dvfy-checkbox__input').click();
+
+      const host = await fixture(html`<dvfy-checkbox name="t2" label="Accept"></dvfy-checkbox>`);
+      let hostCount = 0;
+      host.addEventListener('change', () => { hostCount += 1; });
+      host.click();
+
+      expect(hostCount).to.equal(directCount);
+      expect(hostCount).to.be.greaterThan(0);
+    });
+
+    it('ignores host clicks while disabled', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t" label="Accept" disabled></dvfy-checkbox>`);
+
+      el.click();
+
+      expect(el.querySelector('.dvfy-checkbox__input').checked).to.be.false;
+    });
+
+    // Tristate: assert PARITY, not the cycle itself. A programmatic click does not advance
+    // the tristate cycle even when dispatched directly on the input — pre-existing behaviour,
+    // unrelated to this fix. What this fix owes is that routing through the host changes
+    // nothing, which is what is asserted here.
+    it('a host click leaves tristate in the same state as a direct input click', async () => {
+      const direct = await fixture(html`<dvfy-checkbox name="t" label="All" indeterminate></dvfy-checkbox>`);
+      const di = direct.querySelector('.dvfy-checkbox__input');
+      di.click();
+      await nextFrame();
+
+      const host = await fixture(html`<dvfy-checkbox name="t2" label="All" indeterminate></dvfy-checkbox>`);
+      host.click();
+      await nextFrame();
+      const hi = host.querySelector('.dvfy-checkbox__input');
+
+      expect(hi.checked).to.equal(di.checked);
+      expect(hi.indeterminate).to.equal(di.indeterminate);
     });
   });
 });

--- a/components/dvfy-radio.js
+++ b/components/dvfy-radio.js
@@ -121,10 +121,45 @@ ${labelPositionCSS('dvfy-radio', { layout: 'inline', label: '.dvfy-radio__label'
  * @cssprop {color} --dvfy-input-border - Unselected border color
  */
 class DvfyRadio extends HTMLElement {
+  /** Guards against re-binding the host click handler if the element is re-connected. */
+  #hostActivationBound = false;
+
   connectedCallback() {
     injectStyles('dvfy-radio', STYLES);
     this.setAttribute('role', 'radio');
+    this.#bindHostActivation();
     this.#build();
+  }
+
+  /**
+   * Make the WHOLE host activate the input, not just the input and its label text.
+   *
+   * The host sets `cursor: pointer`, so it already promises the entire element is clickable.
+   * But the input and label are siblings inside it, so any host area outside those two — the
+   * padding a consumer adds to render options as full-width card rows — swallowed the click.
+   * Hover styling covered the whole row while the hit target did not, which reads as a broken
+   * control.
+   *
+   * Bound once on the host (never in #build, which reruns on every attribute change) and
+   * guarded so a forwarded click cannot re-enter: input.click() dispatches a click whose
+   * target IS the input, which bubbles back here and returns early.
+   */
+  #bindHostActivation() {
+    if (this.#hostActivationBound) return;
+    this.#hostActivationBound = true;
+
+    this.addEventListener('click', (event) => {
+      if (this.hasAttribute('disabled')) return;
+
+      const input = this.querySelector('.dvfy-radio__input');
+      if (!input) return;
+
+      // The native control and its <label for=…> already handle themselves.
+      if (event.target === input) return;
+      if (event.target.closest?.('.dvfy-radio__label')) return;
+
+      input.click();
+    });
   }
 
   disconnectedCallback() {}

--- a/components/dvfy-radio.test.js
+++ b/components/dvfy-radio.test.js
@@ -98,4 +98,70 @@ describe('dvfy-radio', () => {
       await checkA11y(el, RADIO_A11Y_RULES);
     });
   });
+
+  describe('whole-host activation', () => {
+    // The host sets cursor:pointer and consumers pad it into a full-width card row, so a
+    // click anywhere on it must select — not only on the input and label text.
+    it('selects when the host padding (not the input or label) is clicked', async () => {
+      const el = await fixture(html`<dvfy-radio name="g" value="a" label="Option A"></dvfy-radio>`);
+      const input = el.querySelector('.dvfy-radio__input');
+      expect(input.checked).to.be.false;
+
+      el.click();
+
+      expect(input.checked).to.be.true;
+      expect(el.hasAttribute('checked')).to.be.true;
+      expect(el.getAttribute('aria-checked')).to.equal('true');
+    });
+
+    // Forwarding must not multiply events: a host click and a direct input click have to
+    // produce the SAME number of change events. (The component emits two today — its own
+    // re-dispatch plus the native one bubbling — which is a separate pre-existing defect;
+    // asserting parity guards this fix without freezing that bug in place.)
+    it('a host click emits the same number of change events as a direct input click', async () => {
+      const direct = await fixture(html`<dvfy-radio name="g" value="a" label="Option A"></dvfy-radio>`);
+      let directCount = 0;
+      direct.addEventListener('change', () => { directCount += 1; });
+      direct.querySelector('.dvfy-radio__input').click();
+
+      const host = await fixture(html`<dvfy-radio name="g2" value="a" label="Option A"></dvfy-radio>`);
+      let hostCount = 0;
+      host.addEventListener('change', () => { hostCount += 1; });
+      host.click();
+
+      expect(hostCount).to.equal(directCount);
+      expect(hostCount).to.be.greaterThan(0);
+    });
+
+    it('unchecks its sibling when the host of another option is clicked', async () => {
+      const wrap = await fixture(html`<div>
+        <dvfy-radio name="grp" value="a" label="A" checked></dvfy-radio>
+        <dvfy-radio name="grp" value="b" label="B"></dvfy-radio>
+      </div>`);
+      const [a, b] = wrap.querySelectorAll('dvfy-radio');
+
+      b.click();
+
+      expect(b.querySelector('.dvfy-radio__input').checked).to.be.true;
+      expect(a.hasAttribute('checked')).to.be.false;
+    });
+
+    it('ignores host clicks while disabled', async () => {
+      const el = await fixture(html`<dvfy-radio name="g" value="a" label="A" disabled></dvfy-radio>`);
+
+      el.click();
+
+      expect(el.querySelector('.dvfy-radio__input').checked).to.be.false;
+    });
+
+    it('still activates after a rebuild from an attribute change', async () => {
+      const el = await fixture(html`<dvfy-radio name="g" value="a" label="A"></dvfy-radio>`);
+      el.setAttribute('label', 'A renamed');
+      await el.updateComplete ?? Promise.resolve();
+
+      el.click();
+
+      expect(el.querySelector('.dvfy-radio__input').checked).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## The defect

`dvfy-radio` and `dvfy-checkbox` both set `cursor: pointer` on the host — telling the user the whole element is clickable — but render the `<input>` and its `<label for>` as **siblings** inside it. Any part of the host outside those two swallows the click.

It is invisible at default size, where the host is barely larger than its contents. It bites the moment a consumer pads the host, which is the standard way to render quiz/survey options as full-width card rows:

```css
.dvfy-quiz__options dvfy-radio {
  width: 100%;
  padding: var(--dvfy-space-3) var(--dvfy-space-4);
  border: …; border-radius: …;
}
.dvfy-quiz__options dvfy-radio:hover { … }   /* host hover — covers the whole row */
```

The hover highlight covers the row; the hit target does not. Reported on devify.me's diagnostic quiz (the storefront's primary CTA flow) — hovering lit up the row, clicking the row did nothing unless you hit the label text.

## The fix

Forward host clicks to the inner input, guarded against re-entry: `input.click()` dispatches a click whose target *is* the input, which bubbles back to the host handler and returns early. Bound once in `connectedCallback` — not in `#build()`, which reruns on every attribute change and would stack listeners. Disabled hosts ignore clicks.

Minimal and non-breaking: no markup change, no API change, existing behaviour on the input and label untouched.

## Two pre-existing defects found while testing — NOT fixed here

Both are orthogonal to this change and behave identically with and without it.

**1. `change` fires twice.** A listener on the host receives two events for one interaction: the component's own re-dispatch, plus the native `change` bubbling up from the input.

```
DIRECT INPUT CLICK -> ["DVFY-RADIO/synthetic", "INPUT/trusted"]
```

**2. `dvfy-checkbox` tristate does not advance on a programmatic click** — not even dispatched directly on the input, and not after a frame.

My first drafts of these tests asserted an absolute event count and a tristate transition, and failed — against behaviour that predates this PR. Rather than encode either bug as expected, **the tests now assert host/input parity**: a host click must do exactly what a direct input click does. That guards this fix without freezing the existing bugs in place, and the parity assertions will keep passing when they are fixed properly.

Filing both separately.

## Verification

- 39/39 on `dvfy-radio` + `dvfy-checkbox` (11 new tests: host-padding activation, event parity, sibling unchecking, disabled, survival across an attribute-driven rebuild, tristate parity)
- **1587/1587** full suite
- `npm run lint` clean — eslint, stylelint, `check:tokens`, `check:dvfy-pref`, `check:taxonomy`

Consuming projects need a re-vendor to pick this up; devify.me will follow.
