### PR TITLE
docs(consuming): warn that bare relative href/action values sanitize to #

### DIFF
--- a/docs/consuming-projects.md
+++ b/docs/consuming-projects.md
@@ -91,6 +91,19 @@ document.querySelector('dvfy-nav-bar .dvfy-nav-bar__bar');
 document.querySelector('dvfy-nav-bar').setAttribute('brand', 'MyApp');
 ```
 
+## `href`/`action`-style attributes must be root- or dot-relative
+
+Any component that accepts a URL-ish attribute (`href`, `action`, `logo`, `cta-href`, etc. — e.g. `dvfy-optin`, `dvfy-thank-you`, `dvfy-chum-page`, `dvfy-nav-bar`) runs it through `sanitizeHref()` (`utils/url.js`) to block `javascript:`/`data:` injection. It only passes through values that are absolute (`http(s)://`), start with `/`, start with `#`, or start with `.` — anything else (including a **bare relative path** like `action="thank-you.html"`, with no leading `./`) silently collapses to `#`, producing a dead link/no-op form submit with no console warning.
+
+```html
+<!-- Wrong: bare relative path sanitizes to "#" -->
+<dvfy-optin action="thank-you.html"></dvfy-optin>
+
+<!-- Right: dot-relative or root-relative -->
+<dvfy-optin action="./thank-you.html"></dvfy-optin>
+<dvfy-optin action="/thank-you.html"></dvfy-optin>
+```
+
 ## When the Component Doesn't Support What You Need
 
 1. **Check all available attributes** — the manifest may have what you need under a different name


### PR DESCRIPTION
## What

Documents a silent failure mode in `docs/consuming-projects.md`: any URL-ish attribute (`href`, `action`, `logo`, `cta-href`) runs through `sanitizeHref()`, which passes only absolute, root-relative (`/`), hash (`#`), or dot-relative (`.`) values. A **bare** relative path like `action="thank-you.html"` collapses to `#` — a dead link or no-op form submit, with no console warning.

## Why it is worth a doc note

This is the workaround side of #381 (open, `priority:high`), which surfaced during the devify.me integration when a header `<img src>` silently rendered as `src="#"`. It cost debugging time once already, and the chum widgets (`dvfy-optin`, `dvfy-thank-you`, `dvfy-chum-page`) all take URL attributes that a page author would naturally write as bare relative paths — so instance #3 is likely to re-pay it.

**#381 stays open.** The sanitizer is still wrong to reject valid same-directory paths; this note only tells consumers how to avoid the trap until the sanitizer is fixed. If #381 lands first, this section should be trimmed to the security rationale rather than deleted — the `javascript:`/`data:` blocking is still worth stating.

## Provenance

The change was found sitting uncommitted on `main` in the working tree, presumably left over from the instance-#2 work. Recovered onto a branch rather than discarded. A second uncommitted file (`tasks/todo.md`, an unstarted plan for #382) was reverted and its content parked on that issue instead.

## Verification

Docs-only, no code or token changes.

Refs #381
