### PR TITLE
fix(radio,checkbox): one change event per interaction, and a tristate cycle that can be driven (#403, #404)

### DIFF
--- a/components/dvfy-checkbox.js
+++ b/components/dvfy-checkbox.js
@@ -329,30 +329,41 @@ class DvfyCheckbox extends HTMLElement {
 
     this.#syncInput(input);
 
-    if (this.#tristate) {
-      input.addEventListener('click', (e) => {
-        e.preventDefault();
-        if (input.disabled) return;
+    // Both the binary and the tri-state control are driven from the input's own `change`.
+    //
+    // Tri-state used to be driven from a `click` handler that called preventDefault(). That
+    // cannot work: cancelling a checkbox click triggers the browser's legacy-canceled-
+    // activation behaviour, which restores checkedness and indeterminate to their pre-click
+    // values AFTER every listener has run -- so the handler's #syncInput() was undone on the
+    // way out and the cycle never advanced in the DOM. It looked like a test-only quirk but it
+    // meant the control could not be driven programmatically at all: no "select all" wiring,
+    // no restoring saved form state (devify-ui#404). Running after the activation behaviour,
+    // from `change`, means nothing is reverted behind us.
+    input.addEventListener('change', (e) => {
+      // The native `change` already bubbles to the host, where the component also dispatches
+      // its own -- two events per interaction for any host listener, which double-counts in
+      // consumers that append, post or track (devify-ui#403). Stop the native one here so the
+      // component's CustomEvent (which carries `detail`) is the single canonical event on the
+      // host and above. A listener on the input itself still gets it: this is a target-phase
+      // listener, and stopPropagation does not cancel siblings.
+      e.stopPropagation();
+
+      if (this.#tristate) {
+        // The browser has already flipped checkedness; advance our own cycle over it.
         if (this.#state === 'indeterminate') this.#state = 'checked';
         else if (this.#state === 'checked') this.#state = 'unchecked';
         else this.#state = 'indeterminate';
-        this.#syncInput(input);
-        this.#syncAttributes();
-        this.dispatchEvent(new CustomEvent('change', {
-          bubbles: true,
-          detail: { checked: input.checked, indeterminate: input.indeterminate }
-        }));
-      });
-    } else {
-      input.addEventListener('change', () => {
+      } else {
         this.#state = input.checked ? 'checked' : 'unchecked';
-        this.#syncAttributes();
-        this.dispatchEvent(new CustomEvent('change', {
-          bubbles: true,
-          detail: { checked: input.checked, indeterminate: false }
-        }));
-      });
-    }
+      }
+
+      this.#syncInput(input);
+      this.#syncAttributes();
+      this.dispatchEvent(new CustomEvent('change', {
+        bubbles: true,
+        detail: { checked: input.checked, indeterminate: input.indeterminate }
+      }));
+    });
 
     this.appendChild(input);
 

--- a/components/dvfy-checkbox.test.js
+++ b/components/dvfy-checkbox.test.js
@@ -90,6 +90,142 @@ describe('dvfy-checkbox', () => {
       expect(ev1.detail.checked).to.be.true;
       expect(ev1.detail.indeterminate).to.be.false;
     });
+
+    // devify-ui#403 — the component re-dispatches its own `change` on the host while the
+    // native one from the inner input also bubbles there, so a host listener ran twice.
+    it('emits exactly one change event to a host listener (binary)', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="c403a" label="Accept"></dvfy-checkbox>`);
+      let count = 0;
+      el.addEventListener('change', () => { count += 1; });
+
+      el.querySelector('.dvfy-checkbox__input').click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('emits exactly one change event to a host listener (tristate)', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="c403b" label="All" indeterminate></dvfy-checkbox>`);
+      let count = 0;
+      el.addEventListener('change', () => { count += 1; });
+
+      el.querySelector('.dvfy-checkbox__input').click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('emits exactly one change event to an ancestor listener', async () => {
+      const wrap = await fixture(html`
+        <div><dvfy-checkbox name="c403c" label="Accept"></dvfy-checkbox></div>
+      `);
+      let count = 0;
+      wrap.addEventListener('change', () => { count += 1; });
+
+      wrap.querySelector('.dvfy-checkbox__input').click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('still delivers the native change to a listener on the input itself', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="c403d" label="Accept"></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+      let count = 0;
+      input.addEventListener('change', () => { count += 1; });
+
+      input.click();
+
+      expect(count).to.equal(1);
+    });
+  });
+
+  // devify-ui#404 — the tristate cycle was driven from a preventDefault()ed click, so the
+  // browser's legacy-canceled-activation behaviour reverted the input to its pre-click state
+  // and the control could not be advanced programmatically at all.
+  describe('tri-state cycle under a programmatic click (#404)', () => {
+    it('advances indeterminate -> checked -> unchecked -> indeterminate', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t404" label="All" indeterminate></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+      expect(input.indeterminate, 'starts indeterminate').to.be.true;
+
+      input.click();
+      await nextFrame();
+      expect(input.checked, 'indeterminate -> checked').to.be.true;
+      expect(input.indeterminate).to.be.false;
+
+      input.click();
+      await nextFrame();
+      expect(input.checked, 'checked -> unchecked').to.be.false;
+      expect(input.indeterminate).to.be.false;
+
+      input.click();
+      await nextFrame();
+      expect(input.checked, 'unchecked -> indeterminate').to.be.false;
+      expect(input.indeterminate).to.be.true;
+    });
+
+    it('advances on a host click too', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t404h" label="All" indeterminate></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+
+      el.click();
+      await nextFrame();
+
+      expect(input.checked).to.be.true;
+      expect(input.indeterminate).to.be.false;
+    });
+
+    it('keeps host attributes and aria-checked in step with the cycle', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t404a" label="All" indeterminate></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+      expect(el.getAttribute('aria-checked')).to.equal('mixed');
+
+      input.click();
+      await nextFrame();
+      expect(el.hasAttribute('checked')).to.be.true;
+      expect(el.hasAttribute('indeterminate')).to.be.false;
+      expect(el.getAttribute('aria-checked')).to.equal('true');
+
+      input.click();
+      await nextFrame();
+      expect(el.hasAttribute('checked')).to.be.false;
+      expect(el.getAttribute('aria-checked')).to.equal('false');
+
+      input.click();
+      await nextFrame();
+      expect(el.hasAttribute('indeterminate')).to.be.true;
+      expect(el.getAttribute('aria-checked')).to.equal('mixed');
+    });
+
+    it('reports the cycle through the checked/indeterminate properties', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t404p" label="All" indeterminate></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+
+      input.click();
+      await nextFrame();
+      expect(el.checked).to.be.true;
+      expect(el.indeterminate).to.be.false;
+
+      input.click();
+      await nextFrame();
+      expect(el.checked).to.be.false;
+      expect(el.indeterminate).to.be.false;
+    });
+
+    it('carries the advanced state in each change event detail', async () => {
+      const el = await fixture(html`<dvfy-checkbox name="t404e" label="All" indeterminate></dvfy-checkbox>`);
+      const input = el.querySelector('.dvfy-checkbox__input');
+      const details = [];
+      el.addEventListener('change', (e) => { details.push(e.detail); });
+
+      input.click();
+      input.click();
+      input.click();
+
+      expect(details).to.deep.equal([
+        { checked: true, indeterminate: false },
+        { checked: false, indeterminate: false },
+        { checked: false, indeterminate: true },
+      ]);
+    });
   });
 
   describe('label', () => {

--- a/components/dvfy-radio.js
+++ b/components/dvfy-radio.js
@@ -184,7 +184,7 @@ class DvfyRadio extends HTMLElement {
     if (this.hasAttribute('disabled')) input.disabled = true;
     if (this.hasAttribute('required')) input.required = true;
 
-    input.addEventListener('change', () => this.#handleChange(input));
+    input.addEventListener('change', e => this.#handleChange(input, e));
 
     this.appendChild(input);
 
@@ -199,8 +199,17 @@ class DvfyRadio extends HTMLElement {
     this.setAttribute('aria-checked', this.hasAttribute('checked') ? 'true' : 'false');
   }
 
-  /** @param {HTMLInputElement} input */
-  #handleChange(input) {
+  /**
+   * @param {HTMLInputElement} input
+   * @param {Event} [nativeEvent] the inner input's own `change`, when there was one
+   */
+  #handleChange(input, nativeEvent) {
+    // `change` from a native input already bubbles, so a host listener saw BOTH it and the
+    // component's re-dispatch below -- two events for one interaction, which double-counts in
+    // any consumer that appends, posts or tracks (devify-ui#403). Stop the native one at the
+    // input so the component's event is the single canonical one on the host and above; a
+    // listener attached to the input itself still receives it (target-phase listeners run).
+    nativeEvent?.stopPropagation();
     if (!input.checked) return;
     this.#uncheckSiblings(input.name);
     this.setAttribute('checked', '');

--- a/components/dvfy-radio.test.js
+++ b/components/dvfy-radio.test.js
@@ -97,6 +97,51 @@ describe('dvfy-radio', () => {
       expect(event.bubbles).to.be.true;
       await checkA11y(el, RADIO_A11Y_RULES);
     });
+
+    // devify-ui#403 — the component re-dispatches its own `change` on the host while the
+    // native one from the inner input also bubbles there, so a host listener ran twice.
+    it('emits exactly one change event to a host listener on a direct input click', async () => {
+      const el = await fixture(html`<dvfy-radio name="p403a" value="pro" label="Pro"></dvfy-radio>`);
+      let count = 0;
+      el.addEventListener('change', () => { count += 1; });
+
+      el.querySelector('.dvfy-radio__input').click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('emits exactly one change event to a host listener on a host click', async () => {
+      const el = await fixture(html`<dvfy-radio name="p403b" value="pro" label="Pro"></dvfy-radio>`);
+      let count = 0;
+      el.addEventListener('change', () => { count += 1; });
+
+      el.click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('emits exactly one change event to an ancestor listener', async () => {
+      const wrap = await fixture(html`
+        <div><dvfy-radio name="p403c" value="pro" label="Pro"></dvfy-radio></div>
+      `);
+      let count = 0;
+      wrap.addEventListener('change', () => { count += 1; });
+
+      wrap.querySelector('.dvfy-radio__input').click();
+
+      expect(count).to.equal(1);
+    });
+
+    it('still delivers the native change to a listener on the input itself', async () => {
+      const el = await fixture(html`<dvfy-radio name="p403d" value="pro" label="Pro"></dvfy-radio>`);
+      const input = el.querySelector('.dvfy-radio__input');
+      let count = 0;
+      input.addEventListener('change', () => { count += 1; });
+
+      input.click();
+
+      expect(count).to.equal(1);
+    });
   });
 
   describe('whole-host activation', () => {


### PR DESCRIPTION
Closes #403. Closes #404.

Two defects in the same pair of controls, so one PR.

## #403 — double `change` to a host listener

Both components re-dispatch their own `change` on the host, but `change` from a native input **already bubbles** there. A host listener therefore ran twice per interaction:

```
DVFY-RADIO  false   <- the component's re-dispatch
INPUT       true    <- the native event bubbling up
```

Harmless for an idempotent handler; wrong for anything that counts, appends, posts or fires analytics — which is precisely what a quiz or funnel step does.

**Fix:** option 1 from the issue. `stopPropagation()` the native event at the input, leaving the component's own event as the single canonical one on the host and above. This keeps the `detail`-carrying seam (`dvfy-checkbox` dispatches a `CustomEvent`) and does not lose the event for anyone listening on the inner input — that is a target-phase listener, and `stopPropagation` does not cancel siblings. There is a test for exactly that.

## #404 — tristate cycle does not advance on a programmatic click

Root cause: the cycle was driven from a `click` handler calling `preventDefault()`. Cancelling a checkbox click triggers the browser's **legacy-canceled-activation behaviour**, which restores `checkedness` and `indeterminate` to their pre-click values *after every listener has run* — so the handler's own `#syncInput()` was undone on the way out.

That is why it reads as a test-only quirk: internal `#state` advanced correctly, the host attributes and `aria-checked` advanced correctly, and the `change` event carried the right `detail` (it is read before the revert). Only the DOM input was silently rolled back. Consequences: no "select all" wiring, no restoring saved form state, no e2e coverage of any tristate flow.

**Fix:** drive the cycle from `change` instead of a cancelled `click`. `change` fires after the activation behaviour, so nothing is reverted behind us, and the browser's own flip is simply overwritten by `#syncInput()`. This also collapses the two divergent handlers (a `click` branch for tristate, a `change` branch for binary) into one.

## Scope note

The issue suggests sweeping every component that re-dispatches a natively-bubbling event. I checked the candidates: `dvfy-slider` (four sites, including a doubled `input` on every drag frame of a range slider) and `dvfy-date-picker` have the same defect; `dvfy-select` already does the right thing and is the in-repo precedent for this fix; `dvfy-switch` and `dvfy-file-upload` are clean. Deliberately **not** included here — different components, different tests, and this PR is already two fixes. Filed as #413.

## Test plan

**Red — new tests on `main`:**

```
❌ dvfy-radio > emits exactly one change event to a host listener on a direct input click
      AssertionError: expected 2 to equal 1
❌ dvfy-radio > emits exactly one change event to a host listener on a host click
      AssertionError: expected 2 to equal 1
❌ dvfy-radio > emits exactly one change event to an ancestor listener
      AssertionError: expected 2 to equal 1
❌ dvfy-checkbox > emits exactly one change event to a host listener (binary)
      AssertionError: expected 2 to equal 1
❌ dvfy-checkbox > emits exactly one change event to an ancestor listener
      AssertionError: expected 2 to equal 1
❌ dvfy-checkbox > tri-state (#404) > advances indeterminate -> checked -> unchecked -> indeterminate
      AssertionError: indeterminate -> checked: expected false to be true
❌ dvfy-checkbox > tri-state (#404) > advances on a host click too
      AssertionError: expected false to be true
❌ dvfy-checkbox > tri-state (#404) > reports the cycle through the checked/indeterminate properties
      AssertionError: expected false to be true
2 test files | 44 passed, 8 failed
```

Note which of the new tests *passed* on `main`, because it pins the diagnosis: "keeps host attributes and aria-checked in step" and "carries the advanced state in each change event detail" were already green. The state machine and the events were always right — only the DOM was being rolled back underneath them.

**Green — after the fix:**

```
components/dvfy-radio.test.js + components/dvfy-checkbox.test.js
2 test files | 52 passed, 0 failed
```

**Full suite, rebased on current `main`:**

```
Chromium: 85/85 test files | 1637 passed, 0 failed
```

The `#402` parity assertions (host click vs direct input click produce the same event count / same tristate result) still hold — they were written to assert parity rather than an absolute count precisely so they would survive this fix, and they did.

`npm run lint` clean.

