### PR TITLE
fix(button): render a real <a href> instead of a fake role=link (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `dvfy-button[href]` — now renders a **real inner `<a href>`** that fills the button box, instead of faking a link with `role="link"` + `window.location.assign()`. The fake link emitted no crawlable link graph (a factory page's only next step was an orphan URL to a search engine), swallowed cmd/middle-click and "open in new tab", and bypassed `hx-boost` on boosted pages. `target`/`rel` pass through to the anchor, `sanitizeHref()` still guards the value, and `disabled`/`loading` strip `href` off the anchor. **Behaviour change for consumers:** the host no longer carries `role="link"` or `tabindex` — the anchor is the single tab stop (removing a nested-interactive a11y violation). A button without `href` is unchanged. (#408)
 - `dvfy-alert`, `dvfy-avatar`, `dvfy-auth`, `dvfy-checkbox` — no longer rebuild their internal DOM on every observed attribute change. Non-structural changes (`status`, `title`, `name`, `label`, `action`, `checked`, `disabled`, OAuth URLs, etc.) now update in place, preserving focus, typed input values, and element references. Fixes flicker during rapid attribute updates such as theme switches or live-edit sandboxes.
 
 ---

--- a/components/dvfy-button.js
+++ b/components/dvfy-button.js
@@ -21,9 +21,15 @@ const STYLES = `
 }
 
 dvfy-button {
+  /* Padding lives in custom properties so that, when an href renders a real inner
+     <a>, the anchor can own the padding box and the whole button surface is a link. */
+  --dvfy-btn-pad-y: var(--dvfy-space-2);
+  --dvfy-btn-pad-x: var(--dvfy-space-4);
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding: var(--dvfy-btn-pad-y) var(--dvfy-btn-pad-x);
   gap: var(--dvfy-space-2);
   font-family: var(--dvfy-font-sans);
   font-weight: var(--dvfy-weight-medium);
@@ -37,22 +43,45 @@ dvfy-button {
 }
 
 /* Size: xs */
-dvfy-button[size="xs"] { padding: var(--dvfy-space-1) var(--dvfy-space-2); font-size: var(--dvfy-text-xs); border-radius: var(--dvfy-radius-sm); }
+dvfy-button[size="xs"] { --dvfy-btn-pad-y: var(--dvfy-space-1); --dvfy-btn-pad-x: var(--dvfy-space-2); font-size: var(--dvfy-text-xs); border-radius: var(--dvfy-radius-sm); }
 /* Size: sm */
-dvfy-button[size="sm"] { padding: var(--dvfy-space-1-5) var(--dvfy-space-3); font-size: var(--dvfy-text-sm); border-radius: var(--dvfy-radius-md); }
+dvfy-button[size="sm"] { --dvfy-btn-pad-y: var(--dvfy-space-1-5); --dvfy-btn-pad-x: var(--dvfy-space-3); font-size: var(--dvfy-text-sm); border-radius: var(--dvfy-radius-md); }
 /* Size: md (default) */
-dvfy-button:not([size]), dvfy-button[size="md"] { padding: var(--dvfy-space-2) var(--dvfy-space-4); font-size: var(--dvfy-text-sm); border-radius: var(--dvfy-radius-lg); }
+dvfy-button:not([size]), dvfy-button[size="md"] { --dvfy-btn-pad-y: var(--dvfy-space-2); --dvfy-btn-pad-x: var(--dvfy-space-4); font-size: var(--dvfy-text-sm); border-radius: var(--dvfy-radius-lg); }
 /* Size: lg */
-dvfy-button[size="lg"] { padding: var(--dvfy-space-2-5) var(--dvfy-space-5); font-size: var(--dvfy-text-base); border-radius: var(--dvfy-radius-lg); }
+dvfy-button[size="lg"] { --dvfy-btn-pad-y: var(--dvfy-space-2-5); --dvfy-btn-pad-x: var(--dvfy-space-5); font-size: var(--dvfy-text-base); border-radius: var(--dvfy-radius-lg); }
 /* Size: xl */
-dvfy-button[size="xl"] { padding: var(--dvfy-space-3) var(--dvfy-space-6); font-size: var(--dvfy-text-lg); border-radius: var(--dvfy-radius-xl); }
+dvfy-button[size="xl"] { --dvfy-btn-pad-y: var(--dvfy-space-3); --dvfy-btn-pad-x: var(--dvfy-space-6); font-size: var(--dvfy-text-lg); border-radius: var(--dvfy-radius-xl); }
 
 /* Icon-only — square aspect ratio */
-dvfy-button[icon] { aspect-ratio: 1; padding: var(--dvfy-space-2); }
-dvfy-button[icon][size="xs"] { padding: var(--dvfy-space-1); }
-dvfy-button[icon][size="sm"] { padding: var(--dvfy-space-1-5); }
-dvfy-button[icon][size="lg"] { padding: var(--dvfy-space-2-5); }
-dvfy-button[icon][size="xl"] { padding: var(--dvfy-space-3); }
+dvfy-button[icon] { aspect-ratio: 1; --dvfy-btn-pad-y: var(--dvfy-space-2); --dvfy-btn-pad-x: var(--dvfy-space-2); }
+dvfy-button[icon][size="xs"] { --dvfy-btn-pad-y: var(--dvfy-space-1); --dvfy-btn-pad-x: var(--dvfy-space-1); }
+dvfy-button[icon][size="sm"] { --dvfy-btn-pad-y: var(--dvfy-space-1-5); --dvfy-btn-pad-x: var(--dvfy-space-1-5); }
+dvfy-button[icon][size="lg"] { --dvfy-btn-pad-y: var(--dvfy-space-2-5); --dvfy-btn-pad-x: var(--dvfy-space-2-5); }
+dvfy-button[icon][size="xl"] { --dvfy-btn-pad-y: var(--dvfy-space-3); --dvfy-btn-pad-x: var(--dvfy-space-3); }
+
+/* Link mode — a real <a> owns the whole padding box, so every pixel of the button is a
+   genuine anchor: crawlable, cmd/middle-clickable, and boostable by htmx. The host keeps
+   the visual chrome (background, border, radius) and gives its padding to the anchor. */
+dvfy-button[href] { padding: 0; }
+dvfy-button > a.dvfy-button__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: inherit;
+  padding: var(--dvfy-btn-pad-y) var(--dvfy-btn-pad-x);
+  font: inherit;
+  color: inherit;
+  text-decoration: none;
+  border-radius: inherit;
+}
+dvfy-button > a.dvfy-button__link:focus-visible {
+  outline: var(--dvfy-ring-width) solid var(--dvfy-ring-color);
+  outline-offset: var(--dvfy-ring-offset);
+}
 
 /* Primary variant (default when no variant specified) — high specificity to resist overrides */
 dvfy-button:not([variant]), dvfy-button[variant="primary"] {
@@ -162,9 +191,9 @@ dvfy-button[loading]::after {
  * @attr {boolean} disabled - Disable button and prevent interaction
  * @attr {boolean} loading - Show loading state with spinner indicator
  * @attr {string} type - HTML button type: button | submit | reset (default: "button")
- * @attr {string} href - When set, the button behaves as a link (role="link") and navigates on click/Enter
- * @attr {string} target - Link target for href navigation (e.g. "_blank"); only applies when href is set
- * @attr {string} rel - Link relationship for href navigation; defaults to "noopener noreferrer" when target="_blank"
+ * @attr {string} href - When set, the button renders a REAL inner `<a href>` (crawlable, cmd-clickable, hx-boostable) that fills the button box
+ * @attr {string} target - Link target, passed through to the anchor (e.g. "_blank"); only applies when href is set
+ * @attr {string} rel - Link relationship, passed through to the anchor; defaults to "noopener noreferrer" when target="_blank"
  * @attr {string} from - Gradient start color for variant="gradient" (default: "#7c3aed")
  * @attr {string} to - Gradient end color for variant="gradient" (default: "#2563eb")
  *
@@ -175,16 +204,19 @@ dvfy-button[loading]::after {
  * @cssprop {color} --dvfy-danger-bg - Danger variant background
  */
 class DvfyButton extends HTMLElement {
+  /** The real <a> rendered for `href` mode (null when the button is not a link). */
+  #anchor = null;
+
+  /** Watches for label content appended after upgrade so it lands inside the anchor. */
+  #childWatcher = null;
+
   connectedCallback() {
     injectStyles('dvfy-button', STYLES);
 
     if (this.hasAttribute('from')) this.style.setProperty('--dvfy-btn-grad-from', this.getAttribute('from'));
     if (this.hasAttribute('to')) this.style.setProperty('--dvfy-btn-grad-to', this.getAttribute('to'));
 
-    this.#syncRole();
-    if (!this.getAttribute('tabindex') && !this.hasAttribute('disabled')) {
-      this.setAttribute('tabindex', '0');
-    }
+    this.#syncLink();
     this.#syncAria();
 
     this.addEventListener('keydown', this.#onKey);
@@ -194,9 +226,22 @@ class DvfyButton extends HTMLElement {
   disconnectedCallback() {
     this.removeEventListener('keydown', this.#onKey);
     this.removeEventListener('click', this.#onClick);
+    this.#childWatcher?.disconnect();
+    this.#childWatcher = null;
+  }
+
+  /** True when the event originated on (or inside) the rendered anchor, i.e. the browser
+   *  is already doing the navigation natively and the JS path must stay out of the way. */
+  #fromAnchor(e) {
+    const a = this.#anchor;
+    return !!a && !!e?.target && (e.target === a || (e.target.nodeType === 1 && a.contains(e.target)));
   }
 
   #onKey = (e) => {
+    // A real anchor handles its own Enter; intervening would double-navigate and would
+    // also swallow the modifier keys the browser uses for "open in new tab/window".
+    if (this.#fromAnchor(e)) return;
+
     // Links activate on Enter only (native anchor semantics); buttons also on Space.
     const isLink = this.hasAttribute('href');
     if (e.key === 'Enter' || (!isLink && e.key === ' ')) {
@@ -208,7 +253,12 @@ class DvfyButton extends HTMLElement {
   #onClick = (e) => {
     if (this.hasAttribute('disabled') || this.hasAttribute('loading')) return;
 
-    // Link behavior takes precedence: navigate when href is present.
+    // The anchor is a real link: let the browser own the click. This is what preserves
+    // cmd/middle-click, "open in new tab", and hx-boost interception.
+    if (this.#fromAnchor(e)) return;
+
+    // Fallback for a click on the host itself (a programmatic .click(), or the 1px border
+    // ring the anchor does not cover, or a consumer that tore the anchor out of the DOM).
     if (this.hasAttribute('href')) {
       this.#navigateFromHref(e);
       return;
@@ -240,19 +290,17 @@ class DvfyButton extends HTMLElement {
   _navigate(url) { window.location.assign(url); }
   _openTab(url, features) { window.open(url, '_blank', features); }
 
-  static get observedAttributes() { return ['disabled', 'loading', 'from', 'to', 'href']; }
+  static get observedAttributes() { return ['disabled', 'loading', 'from', 'to', 'href', 'target', 'rel']; }
 
   attributeChangedCallback(name, _old, value) {
     if (name === 'disabled') {
       const disabled = this.hasAttribute('disabled');
-      this.setAttribute('tabindex', disabled ? '-1' : '0');
       this.setAttribute('aria-disabled', String(disabled));
+      // In link mode the anchor is the tab stop, so the host stays out of the tab order.
+      if (!this.hasAttribute('href')) this.setAttribute('tabindex', disabled ? '-1' : '0');
     }
     if (name === 'loading') {
       this.setAttribute('aria-busy', String(this.hasAttribute('loading')));
-    }
-    if (name === 'href') {
-      this.#syncRole();
     }
     if (name === 'from') {
       this.style.setProperty('--dvfy-btn-grad-from', value ?? '');
@@ -260,14 +308,104 @@ class DvfyButton extends HTMLElement {
     if (name === 'to') {
       this.style.setProperty('--dvfy-btn-grad-to', value ?? '');
     }
+    // Anchor presence and the host's own focusability both depend on href + inert state.
+    if (this.isConnected && ['href', 'target', 'rel', 'disabled', 'loading'].includes(name)) {
+      this.#syncLink();
+    }
   }
 
-  #syncRole() {
-    const role = this.hasAttribute('href') ? 'link' : 'button';
-    // Respect an author-supplied role only if it isn't the one we manage.
-    const current = this.getAttribute('role');
-    if (current === 'link' || current === 'button' || current === null) {
-      this.setAttribute('role', role);
+  // ── Link mode ───────────────────────────────────────────────────────────────
+  // `href` renders a REAL <a> instead of faking one with role="link" +
+  // location.assign(). A fake link is invisible to crawlers (the page ships no link
+  // graph at all), swallows every modifier click, and bypasses hx-boost. See #408.
+
+  #syncLink() {
+    if (this.hasAttribute('href')) this.#renderAnchor(); else this.#removeAnchor();
+    this.#syncHostFocus();
+  }
+
+  #renderAnchor() {
+    let a = this.#anchor;
+    if (!a || a.parentNode !== this) {
+      a = document.createElement('a');
+      a.className = 'dvfy-button__link';
+      // MOVE the label (never clone) so nodes, listeners and IDs survive intact.
+      while (this.firstChild) a.appendChild(this.firstChild);
+      this.appendChild(a);
+      this.#anchor = a;
+      this.#watchChildren();
+    }
+    this.#syncAnchorAttrs();
+  }
+
+  #syncAnchorAttrs() {
+    const a = this.#anchor;
+    if (!a) return;
+
+    // disabled/loading must not leave a navigable, focusable link behind.
+    if (this.hasAttribute('disabled') || this.hasAttribute('loading')) {
+      a.removeAttribute('href');
+      a.removeAttribute('target');
+      a.removeAttribute('rel');
+      a.setAttribute('aria-disabled', 'true');
+      return;
+    }
+    a.removeAttribute('aria-disabled');
+    a.setAttribute('href', sanitizeHref(this.getAttribute('href')));
+
+    const target = this.getAttribute('target');
+    if (target) a.setAttribute('target', target); else a.removeAttribute('target');
+
+    // Safe default for _blank: opener-isolated + no referrer unless the author overrides.
+    const rel = this.getAttribute('rel') || (target === '_blank' ? 'noopener noreferrer' : null);
+    if (rel) a.setAttribute('rel', rel); else a.removeAttribute('rel');
+  }
+
+  #removeAnchor() {
+    const a = this.#anchor;
+    if (a && a.parentNode === this) {
+      while (a.firstChild) this.insertBefore(a.firstChild, a);
+      a.remove();
+    }
+    this.#anchor = null;
+    this.#childWatcher?.disconnect();
+    this.#childWatcher = null;
+  }
+
+  /** Consumers commonly set `.textContent` after appending the element. Re-home any stray
+   *  direct child into the anchor (and rebuild the anchor if it was wiped) so the link
+   *  never silently loses its text — which would leave an anchor with no accessible name. */
+  #watchChildren() {
+    if (this.#childWatcher) return;
+    this.#childWatcher = new MutationObserver(() => {
+      if (!this.hasAttribute('href')) return;
+      this.#childWatcher.disconnect();
+      try {
+        this.#renderAnchor();
+        for (const node of [...this.childNodes]) {
+          if (node !== this.#anchor) this.#anchor.appendChild(node);
+        }
+      } finally {
+        if (this.#childWatcher) this.#childWatcher.observe(this, { childList: true });
+      }
+    });
+    this.#childWatcher.observe(this, { childList: true });
+  }
+
+  /** The anchor is the interactive element in link mode, so the host must NOT be a second
+   *  tab stop or a second `link` in the a11y tree (axe: nested-interactive). */
+  #syncHostFocus() {
+    const managedRole = r => r === 'link' || r === 'button' || r === null;
+    if (this.#anchor) {
+      if (managedRole(this.getAttribute('role'))) this.removeAttribute('role');
+      const t = this.getAttribute('tabindex');
+      if (t === '0' || t === '-1') this.removeAttribute('tabindex');
+      return;
+    }
+    if (managedRole(this.getAttribute('role'))) this.setAttribute('role', 'button');
+    // Respect an author-supplied tabindex (e.g. -1 on decorative in-field toggles).
+    if (!this.getAttribute('tabindex')) {
+      this.setAttribute('tabindex', this.hasAttribute('disabled') ? '-1' : '0');
     }
   }
 

--- a/components/dvfy-button.test.js
+++ b/components/dvfy-button.test.js
@@ -73,11 +73,140 @@ describe('dvfy-button', () => {
     });
   });
 
-  describe('href navigation', () => {
-    it('sets role=link (not button) when href is present', async () => {
+  // Swallows the anchor's default navigation AFTER the component's own host handler has
+  // run, so a test can dispatch a real click on a real link without the runner navigating.
+  // Returns { prevented } — whether anything upstream of the wrapper called preventDefault.
+  const guardNavigation = (el) => {
+    const seen = { prevented: null };
+    el.parentElement.addEventListener('click', (e) => {
+      seen.prevented = e.defaultPrevented;
+      e.preventDefault();
+    }, { once: true });
+    return seen;
+  };
+
+  // #408 — a button with an href must be a REAL anchor: crawlable by search engines,
+  // cmd/middle-clickable, and visible to hx-boost. role="link" + location.assign() is a
+  // fake link: it produces no link graph and swallows every modifier click.
+  describe('real anchor (href)', () => {
+    it('renders a real <a href> carrying the label', async () => {
       const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
-      expect(el.getAttribute('role')).to.equal('link');
+      const a = el.querySelector('a');
+      expect(a, 'no <a> rendered — the link is not crawlable').to.exist;
+      expect(a.getAttribute('href')).to.equal('/cuestionario');
+      expect(a.textContent.trim()).to.equal('Go');
+      await checkA11y(el);
+    });
+
+    it('moves the existing label nodes into the anchor (no clone, listeners survive)', async () => {
+      const el = await fixture(html`<dvfy-button href="/x"><span id="lbl">Go</span></dvfy-button>`);
+      const span = el.querySelector('#lbl');
+      let clicked = 0;
+      span.addEventListener('click', () => { clicked += 1; });
+      expect(span.parentElement.tagName).to.equal('A');
+      guardNavigation(el);
+      span.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      expect(clicked).to.equal(1);
+    });
+
+    it('makes the anchor the single tab stop — the host is not nested-interactive', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      expect(el.getAttribute('role'), 'host must not duplicate the anchor role').to.not.equal('link');
+      expect(el.hasAttribute('tabindex'), 'host must not be a second tab stop').to.be.false;
+      const a = el.querySelector('a');
+      a.focus();
+      expect(document.activeElement).to.equal(a);
+      await checkA11y(el);
+    });
+
+    it('does not hijack a cmd/meta-click — the browser opens a new tab', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      let navigated = false;
+      el._navigate = () => { navigated = true; };
+      const a = el.querySelector('a');
+      const seen = guardNavigation(el);
+      a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, metaKey: true }));
+      expect(navigated, 'component navigated the current tab on a cmd-click').to.be.false;
+      expect(seen.prevented, 'component preventDefault-ed a modifier click').to.be.false;
+    });
+
+    it('does not preventDefault a plain click on the anchor (hx-boost sees it)', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      let navigated = false;
+      el._navigate = () => { navigated = true; };
+      const a = el.querySelector('a');
+      const seen = guardNavigation(el);
+      a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      expect(navigated, 'JS navigation ran alongside the native anchor').to.be.false;
+      expect(seen.prevented, 'component preventDefault-ed a plain anchor click (hx-boost would never see it)').to.be.false;
+    });
+
+    it('sanitizes the anchor href (javascript: becomes #)', async () => {
+      const el = await fixture(html`<dvfy-button href="javascript:alert(1)">Bad</dvfy-button>`);
+      expect(el.querySelector('a').getAttribute('href')).to.equal('#');
+    });
+
+    it('passes target through and defaults rel for target=_blank', async () => {
+      const el = await fixture(html`<dvfy-button href="https://example.com" target="_blank">Ext</dvfy-button>`);
+      const a = el.querySelector('a');
+      expect(a.getAttribute('target')).to.equal('_blank');
+      expect(a.getAttribute('rel')).to.contain('noopener');
+      expect(a.getAttribute('rel')).to.contain('noreferrer');
+    });
+
+    it('honors an explicit rel on the anchor', async () => {
+      const el = await fixture(html`<dvfy-button href="https://example.com" target="_blank" rel="noopener">Ext</dvfy-button>`);
+      expect(el.querySelector('a').getAttribute('rel')).to.equal('noopener');
+    });
+
+    it('creates the anchor when href is added dynamically', async () => {
+      const el = await fixture(html`<dvfy-button>Plain</dvfy-button>`);
+      expect(el.querySelector('a')).to.not.exist;
+      el.setAttribute('href', '/later');
+      const a = el.querySelector('a');
+      expect(a).to.exist;
+      expect(a.getAttribute('href')).to.equal('/later');
+      expect(a.textContent.trim()).to.equal('Plain');
+    });
+
+    it('unwraps the anchor (keeping the label) when href is removed', async () => {
+      const el = await fixture(html`<dvfy-button href="/x">Go</dvfy-button>`);
+      el.removeAttribute('href');
+      expect(el.querySelector('a')).to.not.exist;
+      expect(el.textContent.trim()).to.equal('Go');
+      expect(el.getAttribute('role')).to.equal('button');
       expect(el.getAttribute('tabindex')).to.equal('0');
+    });
+
+    it('updates the anchor href when the attribute changes', async () => {
+      const el = await fixture(html`<dvfy-button href="/a">Go</dvfy-button>`);
+      el.setAttribute('href', '/b');
+      expect(el.querySelector('a').getAttribute('href')).to.equal('/b');
+    });
+
+    it('strips href from the anchor while disabled (not navigable, not focusable)', async () => {
+      const el = await fixture(html`<dvfy-button href="/x" disabled>Go</dvfy-button>`);
+      const a = el.querySelector('a');
+      expect(a.hasAttribute('href')).to.be.false;
+      expect(a.getAttribute('aria-disabled')).to.equal('true');
+      el.removeAttribute('disabled');
+      expect(el.querySelector('a').getAttribute('href')).to.equal('/x');
+    });
+
+    it('adopts label content appended after upgrade so it stays inside the anchor', async () => {
+      const el = await fixture(html`<dvfy-button href="/x"></dvfy-button>`);
+      el.appendChild(document.createTextNode('Late label'));
+      await new Promise(r => setTimeout(r, 0));
+      const a = el.querySelector('a');
+      expect(a.textContent.trim()).to.equal('Late label');
+      expect(el.childElementCount).to.equal(1);
+    });
+  });
+
+  describe('href navigation', () => {
+    it('keeps the host out of the accessibility tree as a link when href is present', async () => {
+      const el = await fixture(html`<dvfy-button href="/cuestionario">Go</dvfy-button>`);
+      expect(el.getAttribute('role')).to.not.equal('link');
       await checkA11y(el);
     });
 
@@ -149,11 +278,11 @@ describe('dvfy-button', () => {
       expect(navigated).to.equal(false);
     });
 
-    it('switches role from button to link when href is added dynamically', async () => {
+    it('drops the button role when href is added dynamically', async () => {
       const el = await fixture(html`<dvfy-button>Plain</dvfy-button>`);
       expect(el.getAttribute('role')).to.equal('button');
       el.setAttribute('href', '/later');
-      expect(el.getAttribute('role')).to.equal('link');
+      expect(el.getAttribute('role')).to.not.equal('button');
     });
   });
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -350,16 +350,6 @@
           "type": "string"
         },
         {
-          "name": "target",
-          "description": "Link target for href navigation (e.g. \"_blank\"); only applies when href is set",
-          "type": "string"
-        },
-        {
-          "name": "rel",
-          "description": "Link relationship for href navigation; defaults to \"noopener noreferrer\" when target=\"_blank\"",
-          "type": "string"
-        },
-        {
           "name": "disabled",
           "description": "Disable button and prevent interaction",
           "type": "boolean"
@@ -381,7 +371,17 @@
         },
         {
           "name": "href",
-          "description": "When set, the button behaves as a link (role=\"link\") and navigates on click/Enter",
+          "description": "When set, the button renders a REAL inner `<a href>` (crawlable, cmd-clickable, hx-boostable) that fills the button box",
+          "type": "string"
+        },
+        {
+          "name": "target",
+          "description": "Link target, passed through to the anchor (e.g. \"_blank\"); only applies when href is set",
+          "type": "string"
+        },
+        {
+          "name": "rel",
+          "description": "Link relationship, passed through to the anchor; defaults to \"noopener noreferrer\" when target=\"_blank\"",
           "type": "string"
         }
       ],

--- a/docs/consuming-projects.md
+++ b/docs/consuming-projects.md
@@ -112,6 +112,24 @@ The rule is about the **scheme**, not the shape:
 
 > Before devify-ui#381 (fixed 2026-08-27) the sanitizer was a *prefix* allowlist and a bare relative path such as `action="thank-you.html"` or `logo="assets/x.svg"` silently collapsed to `#`. If your project carries a `./`-prefix workaround for that, it is no longer needed (it still works).
 
+## `dvfy-button[href]` renders a real `<a>` — target it accordingly
+
+A `dvfy-button` with an `href` renders a genuine inner `<a class="dvfy-button__link" href>` that
+fills the button box. That is what makes the CTA crawlable (the page ships a real link graph),
+cmd/middle-clickable, and visible to `hx-boost`. Consequences for consumers:
+
+- The host element is **not** the link. It carries no `role="link"` and no `tabindex`; the anchor
+  is the single tab stop. Don't assert on `dvfy-button[role="link"]`.
+- `el.textContent` still reads the label, but `el.firstElementChild` is the anchor. Setting
+  `el.textContent = '…'` after upgrade is re-homed into the anchor automatically.
+- A button **without** `href` is unchanged: `role="button"`, `tabindex="0"`, no anchor.
+- `disabled`/`loading` strip `href` off the anchor, so it is neither navigable nor focusable.
+
+```html
+<!-- Emits: <dvfy-button href="/cuestionario"><a class="dvfy-button__link" href="/cuestionario">Empezar</a></dvfy-button> -->
+<dvfy-button href="/cuestionario" variant="primary">Empezar</dvfy-button>
+```
+
 ## When the Component Doesn't Support What You Need
 
 1. **Check all available attributes** — the manifest may have what you need under a different name

--- a/scripts/verify-button-href.mjs
+++ b/scripts/verify-button-href.mjs
@@ -61,13 +61,37 @@ page.on('pageerror', e => consoleErrors.push(String(e)));
 try {
   console.log(`button href e2e — ${base}\n`);
 
-  // 1. role=link semantics applied by the real component.
+  // 1. A REAL crawlable anchor — the link graph a search engine can follow (#408).
   await page.goto(base + '/', { waitUntil: 'networkidle' });
   await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
+  const anchorHref = await page.getAttribute('#cta a', 'href');
+  anchorHref === '/cuestionario'
+    ? ok('href button renders a real <a href="/cuestionario">')
+    : fail(`no crawlable anchor — #cta a[href] is ${anchorHref}`);
+  const anchorText = (await page.textContent('#cta a').catch(() => ''))?.trim();
+  anchorText === 'Empezar' ? ok('anchor carries the label text') : fail(`anchor text is ${JSON.stringify(anchorText)}`);
+
+  // The host must not duplicate the anchor: one tab stop, no nested interactive.
   const ctaRole = await page.getAttribute('#cta', 'role');
+  const ctaTabindex = await page.getAttribute('#cta', 'tabindex');
+  ctaRole === null && ctaTabindex === null
+    ? ok('host is not a second link/tab stop')
+    : fail(`host still interactive — role=${ctaRole} tabindex=${ctaTabindex}`);
   const plainRole = await page.getAttribute('#plain', 'role');
-  ctaRole === 'link' ? ok('href button has role=link') : fail(`cta role=${ctaRole}, expected link`);
   plainRole === 'button' ? ok('no-href button keeps role=button') : fail(`plain role=${plainRole}, expected button`);
+
+  // Tab reaches the anchor (keyboard users get the link, not a dead custom element).
+  await page.keyboard.press('Tab');
+  const focusTag = await page.evaluate(() => document.activeElement?.tagName);
+  focusTag === 'A' ? ok('Tab focuses the anchor') : fail(`Tab focused ${focusTag}, expected A`);
+
+  // A plain click must reach the anchor un-prevented, or hx-boost never sees it.
+  const notPrevented = await page.evaluate(() => new Promise((resolve) => {
+    const a = document.querySelector('#cta a');
+    document.addEventListener('click', (e) => { const clean = !e.defaultPrevented; e.preventDefault(); resolve(clean); }, { once: true });
+    a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  }));
+  notPrevented ? ok('plain click is not preventDefault-ed (hx-boost can intercept)') : fail('component preventDefault-ed the anchor click — hx-boost is bypassed');
 
   // 2. Click on the href CTA REALLY navigates (no stub).
   await Promise.all([
@@ -80,14 +104,21 @@ try {
   // 3. Enter key on the href CTA REALLY navigates.
   await page.goto(base + '/', { waitUntil: 'networkidle' });
   await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
-  await page.focus('#cta');
+  await page.focus('#cta a');
   await Promise.all([
     page.waitForURL('**/cuestionario'),
     page.keyboard.press('Enter'),
   ]).catch(() => {});
   page.url().endsWith('/cuestionario') ? ok('Enter on href CTA navigated') : fail(`Enter did not navigate — url ${page.url()}`);
 
-  // 4. A plain button must NOT navigate (regression guard).
+  // 4. A modifier click must NOT navigate the current tab (cmd/ctrl-click stays usable).
+  await page.goto(base + '/', { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
+  await page.click('#cta', { modifiers: ['ControlOrMeta'] });
+  await page.waitForTimeout(250);
+  page.url().endsWith('/') ? ok('ctrl/cmd-click did NOT navigate the current tab') : fail(`modifier click hijacked the current tab → ${page.url()}`);
+
+  // 5. A plain button must NOT navigate (regression guard).
   await page.goto(base + '/', { waitUntil: 'networkidle' });
   await page.waitForFunction(() => customElements.get('dvfy-button') !== undefined);
   await page.click('#plain');


### PR DESCRIPTION
Closes #408.

## Problem

`dvfy-button[href]` never emitted an `<a href>`. It set `role="link"` and navigated from a JS click handler via `window.location.assign()`. Three failures at once:

- **No crawlable link graph** — the emitted page contains zero `<a>`, so the funnel's next step is an orphan URL to a search engine.
- **Modifier clicks swallowed** — no cmd/middle-click, no "open in new tab", no "copy link address", no hover status-bar preview.
- **hx-boost bypassed** — `location.assign` forces a full reload where a boosted swap was intended.

## Fix

When `href` is present the component renders a real inner `<a class="dvfy-button__link" href>` that **owns the button's padding box**, so every pixel of the button is a genuine link. Button padding moved into `--dvfy-btn-pad-y/--dvfy-btn-pad-x` custom properties and the host sets `padding: 0` in link mode; outer geometry is byte-identical to before (verified: a `size="lg"` link button and a plain one both measure 112.5 × 42, with the anchor filling 110.5 × 40 inside the 1px border).

- Label nodes are **moved** into the anchor (never cloned), so IDs, listeners and references survive. A `MutationObserver` re-homes label content appended after upgrade.
- `target`/`rel` pass through to the anchor; `_blank` still defaults to `rel="noopener noreferrer"`; `sanitizeHref()` still guards the value.
- `disabled`/`loading` strip `href` off the anchor — not navigable, not focusable.
- The JS navigation path survives only as a fallback for host-level clicks (a programmatic `.click()`, the 1px border ring, or a consumer that tore the anchor out).

### Behaviour change for consumers

The host **no longer carries `role="link"` or `tabindex`** when `href` is set — the anchor is the single tab stop. That is deliberate: a `role="link"` host wrapping a focusable anchor is a nested-interactive a11y violation and a duplicate tab stop. A button *without* `href` is completely unchanged (`role="button"`, `tabindex="0"`, no anchor). Documented in `docs/consuming-projects.md`.

## Test plan

New `real anchor (href)` suite in `components/dvfy-button.test.js` — 13 tests, **red before / green after**:

Before the fix (13 failures):

```
❌ real anchor (href) > renders a real <a href> carrying the label
     AssertionError: no <a> rendered — the link is not crawlable: expected null to exist
❌ real anchor (href) > makes the anchor the single tab stop — the host is not nested-interactive
     AssertionError: host must not duplicate the anchor role: expected 'link' to not equal 'link'
❌ real anchor (href) > does not hijack a cmd/meta-click — the browser opens a new tab
     TypeError: Cannot read properties of null (reading 'dispatchEvent')
   … 10 more
Chromium: 21 passed, 13 failed
```

After:

```
Chromium: | 1/1 test files | 34 passed, 0 failed
```

Full suite:

```
Chromium: | 84/84 test files | 1600 passed, 0 failed
Finished running tests in 5.9s, all tests passed! 🎉
```

Real-browser e2e (`node scripts/verify-button-href.mjs`, extended with crawlability, tab-stop, un-prevented-click and modifier-click assertions):

```
  ok — href button renders a real <a href="/cuestionario">
  ok — anchor carries the label text
  ok — host is not a second link/tab stop
  ok — no-href button keeps role=button
  ok — Tab focuses the anchor
  ok — plain click is not preventDefault-ed (hx-boost can intercept)
  ok — click on href CTA navigated to /cuestionario
  ok — Enter on href CTA navigated
  ok — ctrl/cmd-click did NOT navigate the current tab
  ok — no-href button did NOT navigate
  ok — no console / page errors
✓ button href e2e passed — CTA navigation is real
```

`npm run lint`, `npm run build`, `npm run contrast:ci` and `npm run analyze` all green.

## Acceptance criteria

- [x] `dvfy-button[href]` produces `<a href>` in the DOM.
- [x] Regression test asserts an anchor exists and that cmd-click does not navigate the current tab.
- [ ] rueda's homepage serves a crawlable link to `/cuestionario` — needs a rueda-side rebuild/deploy with this version; the library half is done here. (Note the wider gap is #409: emitted pages ship no prerendered HTML at all, so the anchor only exists after the module executes.)