### PR TITLE
fix(toast): export DvfyToast so the documented show() API is reachable (#401)

### DIFF
--- a/components/dvfy-toast.js
+++ b/components/dvfy-toast.js
@@ -12,6 +12,7 @@ import { injectStyles } from '../utils/styles.js';
  *   DvfyToast.show({ message, status, duration, position })
  *
  * Usage:
+ *   import { DvfyToast } from '@devify/ui/components/dvfy-toast.js';
  *   DvfyToast.show({ message: 'Saved!', status: 'success' })
  */
 
@@ -278,5 +279,14 @@ class DvfyToast extends HTMLElement {
 
 customElements.define('dvfy-toast', DvfyToast);
 
-// Export for static usage
+// dvfy-toast is the one component whose PRIMARY api is imperative, so unlike the rest of the
+// library it has to be importable, not merely registered. Without these the documented
+// `DvfyToast.show()` entry point was unreachable and every consumer had to rediscover
+// `customElements.get('dvfy-toast')` (devify-ui#401). The `customElements.define` side effect
+// above is unchanged, so declarative `<dvfy-toast>` usage is unaffected.
+export { DvfyToast };
+export default DvfyToast;
+
+// Retained for `patterns/dvfy-htmx-form.js`, which feature-detects the global rather than
+// importing the module, and for non-module <script> consumers of dist/devify.min.js.
 if (typeof window !== 'undefined') window.DvfyToast = DvfyToast;

--- a/components/dvfy-toast.test.js
+++ b/components/dvfy-toast.test.js
@@ -119,6 +119,55 @@ describe('dvfy-toast', () => {
     });
   });
 
+  // devify-ui#401 — the module documents `DvfyToast.show()` as its entry point but never
+  // exported the class, so the documented import was `undefined` and every consumer had to
+  // rediscover the `customElements.get('dvfy-toast')` workaround. The tests below did not
+  // catch it because the rest of this file reaches DvfyToast through the `window` global.
+  //
+  // Identity assertions use `=== ... to.be.true` rather than `to.equal(SomeClass)`: on
+  // failure chai inspects both operands to build a diff, and inspecting a custom-element
+  // constructor wedges the runner (the test file times out instead of failing).
+  describe('module exports (#401)', () => {
+    it('exports the class as a named export', async () => {
+      const mod = await import('./dvfy-toast.js');
+      expect(mod.DvfyToast).to.be.a('function');
+    });
+
+    it('exports the class as the default export', async () => {
+      const mod = await import('./dvfy-toast.js');
+      expect(mod.default).to.be.a('function');
+      expect(mod.default === mod.DvfyToast).to.be.true;
+    });
+
+    it('exports the same class the registry holds', async () => {
+      const mod = await import('./dvfy-toast.js');
+      expect(mod.DvfyToast === customElements.get('dvfy-toast')).to.be.true;
+    });
+
+    // Asserts the element and its container, not the rendered message: this suite's
+    // afterEach removes the containers from the DOM but getContainer() keeps handing back
+    // the cached, now-detached one, so a toast created after the first test never connects
+    // and never renders. That is a real component bug, filed separately -- not this one.
+    it('the documented DvfyToast.show() call works through the import', async () => {
+      const mod = await import('./dvfy-toast.js');
+      const toast = mod.DvfyToast.show({ message: 'From the import', status: 'success' });
+      expect(toast.tagName).to.equal('DVFY-TOAST');
+      expect(toast.getAttribute('status')).to.equal('success');
+      expect(toast.parentElement.classList.contains('dvfy-toast-container')).to.be.true;
+      toast.remove();
+    });
+
+    it('still registers the element as a side effect of importing', async () => {
+      await import('./dvfy-toast.js');
+      expect(customElements.get('dvfy-toast')).to.exist;
+    });
+
+    it('still exposes the window global that dvfy-htmx-form relies on', async () => {
+      const mod = await import('./dvfy-toast.js');
+      expect(window.DvfyToast === mod.DvfyToast).to.be.true;
+    });
+  });
+
   describe('ARIA', () => {
     it('sets role="alert"', async () => {
       const el = await fixture(html`<dvfy-toast>ARIA test</dvfy-toast>`);


### PR DESCRIPTION
Closes #401.

## Problem

`components/dvfy-toast.js` documents its entry point as `DvfyToast.show({ message, status, duration, position })` but never exported the class — it only called `customElements.define('dvfy-toast', DvfyToast)`. So the documented import was `undefined`, and every consumer had to rediscover the registry workaround.

`dvfy-toast` is the one component whose *primary* API is imperative — everything else in the library is consumed declaratively — which is exactly why it is the one that needed to be importable and the one that wasn't.

## Fix

`export { DvfyToast }` + `export default DvfyToast`. Non-breaking:

- The `customElements.define` side effect is untouched, so declarative `<dvfy-toast>` usage is unaffected.
- `window.DvfyToast` stays. It is not dead code: `patterns/dvfy-htmx-form.js` feature-detects the global (`typeof window.DvfyToast !== 'undefined'`) rather than importing the module, so that the pattern degrades gracefully when toast is not loaded. Removing it would break that. There is a test pinning it.
- The module docstring now shows the import alongside the call.

## The sweep the issue asked for came back empty

"Worth a sweep for the same omission on any other component with static methods." Checked: `dvfy-toast.js:185` is the **only** public static method in `components/` and `patterns/` (87 `customElements.define` calls, one static method). No other component has a reachable API that the missing export could have hidden, so there is nothing else to fix here.

## Two things found on the way, filed separately

1. **The tests never caught this** because the rest of `dvfy-toast.test.js` reaches `DvfyToast` through the `window` global rather than an import — the global was masking the missing export in the one place that would have detected it. Fixed implicitly: the new tests go through the import.
2. **`getContainer()` caches a container that may no longer be in the DOM.** Once a cached container is removed, every subsequent `show()` appends into a detached node, so the toast never connects, never renders, and never appears. Reproduced — filed as #416. Not fixed here, to keep this PR single-purpose. It is why the new `show()` test asserts on the element and its container rather than on rendered message text.

The emoji-vs-SVG status icons the issue raises as "minor, related" are also left out deliberately — the issue offers to split them, and they are a visual change with a different test shape.

## Test plan

**Red — new tests before the export:**

```
❌ dvfy-toast > module exports (#401) > exports the class as a named export
      AssertionError: expected undefined to be a function
❌ dvfy-toast > module exports (#401) > exports the class as the default export
      AssertionError: expected undefined to be a function
❌ dvfy-toast > module exports (#401) > exports the same class the registry holds
      AssertionError: expected false to be true
❌ dvfy-toast > module exports (#401) > the documented DvfyToast.show() call works through the import
      TypeError: Cannot read properties of undefined (reading 'show')
❌ dvfy-toast > module exports (#401) > still exposes the window global that dvfy-htmx-form relies on
      AssertionError: expected false to be true
1 test files | 18 passed, 5 failed
```

**Green — after the export:**

```
components/dvfy-toast.test.js | 23 passed, 0 failed
```

**Full suite:**

```
Chromium: 85/85 test files | 1630 passed, 0 failed
```

`npm run lint`, `npm run build` and `npm run analyze` all clean (`custom-elements.json` unchanged — no API surface in the manifest moved).

### One test-authoring note, in the code as a comment

The identity assertions use `expect(a === b).to.be.true` rather than `expect(a).to.equal(b)`. With a custom-element constructor as an operand, chai's failure path inspects both sides to build a diff and **wedges the runner** — the test file times out after 120s instead of failing. Cost me a bisect to find; the comment is there so the next person doesn't repeat it.

